### PR TITLE
Feat 35/style fix

### DIFF
--- a/src/components/Affiliation/AffiliationCarousel.js
+++ b/src/components/Affiliation/AffiliationCarousel.js
@@ -10,7 +10,7 @@ const styles = StyleSheet.create({
     height: 208,
     backgroundColor: colors.blue['000'],
     paddingVertical: 30,
-    paddingHorizontal: 20,
+    // paddingHorizontal: 20,
   },
   activeOrangeContainer: {
     backgroundColor: colors.orange['050'],
@@ -22,8 +22,17 @@ const AffiliationCarousel = ({ isOrange = false }) => {
     <View style={[styles.container, isOrange && styles.activeOrangeContainer]}>
       <FlatList
         data={AFFILIATION_CAROUSEL_DATA}
-        renderItem={({ item }) => (
-          <AffiliationCarouselItem item={item} isOrange={isOrange} />
+        renderItem={({ item, index }) => (
+          <View
+            style={[
+              index === 0 && { marginLeft: 20 },
+              index === AFFILIATION_CAROUSEL_DATA.length - 1 && {
+                marginRight: 20,
+              },
+            ]}
+          >
+            <AffiliationCarouselItem item={item} isOrange={isOrange} />
+          </View>
         )}
         keyExtractor={(item) => item.id}
         horizontal

--- a/src/components/Affiliation/AffiliationColumnList.js
+++ b/src/components/Affiliation/AffiliationColumnList.js
@@ -40,9 +40,11 @@ const styles = StyleSheet.create({
     borderColor: colors.orange[400],
   },
   activityTypeSelectorOrangeButtonTextPressed: {
+    ...typography.body4Regular,
     color: colors.orange[600],
   },
   activityTypeSelectorButtonTextPressed: {
+    ...typography.body4Regular,
     color: colors.blue[600],
   },
   activityList: {

--- a/src/components/Affiliation/AffiliationColumnList.js
+++ b/src/components/Affiliation/AffiliationColumnList.js
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
   },
   activityList: {
     width: '100%',
-    height: '100%',
+    // height: '100%',
     backgroundColor: colors.common.white,
     marginTop: 20,
   },

--- a/src/components/Affiliation/AffiliationColumnListItem.js
+++ b/src/components/Affiliation/AffiliationColumnListItem.js
@@ -18,6 +18,7 @@ const styles = StyleSheet.create({
     height: 108,
     backgroundColor: colors.common.white,
     alignItems: 'center',
+    marginLeft: -10,
   },
   content: {
     flexDirection: 'column',

--- a/src/components/Affiliation/AffiliationColumnListItem.js
+++ b/src/components/Affiliation/AffiliationColumnListItem.js
@@ -13,9 +13,9 @@ import useAuthStore from '../../store/authStore';
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    gap: 16,
+    gap: 4,
     width: '100%',
-    height: 72,
+    height: 108,
     backgroundColor: colors.common.white,
     alignItems: 'center',
   },
@@ -26,13 +26,13 @@ const styles = StyleSheet.create({
     ...typography.body4Bold,
   },
   placeAndDate: {
-    marginTop: 8,
+    marginTop: 12,
     // gap: 4,
   },
   placeAndDateItem: {
     flexDirection: 'row',
-    gap: 4,
-    height: 20,
+    gap: 6,
+    height: 30,
     alignItems: 'center',
   },
   place: {
@@ -46,21 +46,21 @@ const styles = StyleSheet.create({
     marginTop: -2,
   },
   image: {
-    width: 72,
-    height: 72,
+    width: 108,
+    height: 108,
     position: 'relative',
   },
   imageContainer: {
     position: 'relative',
-    width: 72,
-    height: 72,
+    width: 108,
+    height: 108,
   },
   unlikedIcon: {
     position: 'absolute',
-    top: 12.5,
-    left: 12.5,
-    width: 12,
-    height: 12,
+    top: 18.75,
+    left: 18.75,
+    width: 18,
+    height: 18,
   },
 });
 
@@ -93,20 +93,20 @@ const AffiliationColumnListItem = ({ item, navigation }) => {
           <Image source={item.image} style={styles.image} />
           <Pressable style={styles.unlikedIcon} onPress={handleLikePress}>
             {liked ? (
-              <LikedIcon width={12} height={12} color={colors.orange[500]} />
+              <LikedIcon width={18} height={18} color={colors.orange[500]} />
             ) : (
-              <UnlikedIcon width={12} height={12} />
+              <UnlikedIcon width={18} height={18} />
             )}
           </Pressable>
         </View>
       ) : (
         <View style={styles.imageContainer}>
-          <PlaceHolderImage width={72} height={72} style={styles.image} />
+          <PlaceHolderImage width={108} height={108} style={styles.image} />
           <Pressable style={styles.unlikedIcon} onPress={handleLikePress}>
             {liked ? (
-              <LikedIcon width={12} height={12} color={colors.orange[500]} />
+              <LikedIcon width={18} height={18} color={colors.orange[500]} />
             ) : (
-              <UnlikedIcon width={12} height={12} />
+              <UnlikedIcon width={18} height={18} />
             )}
           </Pressable>
         </View>
@@ -115,13 +115,13 @@ const AffiliationColumnListItem = ({ item, navigation }) => {
         <Text style={styles.title}>{item.title}</Text>
         <View style={styles.placeAndDate}>
           <View style={styles.placeAndDateItem}>
-            <PlaceIcon width={16} height={16} color={colors.gray[300]} />
+            <PlaceIcon width={24} height={24} color={colors.gray[300]} />
             <Text style={styles.place}>{item.place}</Text>
           </View>
           <View style={styles.placeAndDateItem}>
             <CalendarIcon
-              width={20}
-              height={20}
+              width={30}
+              height={30}
               color={colors.gray[300]}
               style={{ marginLeft: -2 }}
             />

--- a/src/components/Affiliation/AffiliationColumnListItem.js
+++ b/src/components/Affiliation/AffiliationColumnListItem.js
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
   },
   title: {
-    ...typography.body4Bold,
+    ...typography.body3Bold,
   },
   placeAndDate: {
     marginTop: 12,
@@ -116,13 +116,13 @@ const AffiliationColumnListItem = ({ item, navigation }) => {
         <Text style={styles.title}>{item.title}</Text>
         <View style={styles.placeAndDate}>
           <View style={styles.placeAndDateItem}>
-            <PlaceIcon width={24} height={24} color={colors.gray[300]} />
+            <PlaceIcon width={16} height={16} color={colors.gray[300]} />
             <Text style={styles.place}>{item.place}</Text>
           </View>
           <View style={styles.placeAndDateItem}>
             <CalendarIcon
-              width={30}
-              height={30}
+              width={20}
+              height={20}
               color={colors.gray[300]}
               style={{ marginLeft: -2 }}
             />

--- a/src/components/CouncilMainTab.js
+++ b/src/components/CouncilMainTab.js
@@ -64,11 +64,13 @@ const CouncilMainTab = () => {
                 paddingTop: 20,
                 paddingHorizontal: 20,
                 marginBottom: 10,
+                backgroundColor: colors.common.white,
               }
             : {
                 height: 91,
                 paddingTop: 20,
                 paddingHorizontal: 20,
+                backgroundColor: colors.common.white,
               },
         tabBarItemStyle: { height: 51, width: 67, gap: 6 },
         tabBarLabelStyle: [
@@ -112,11 +114,13 @@ const CouncilMainTab = () => {
                   paddingTop: 20,
                   paddingHorizontal: 20,
                   marginBottom: 10,
+                  backgroundColor: colors.common.white,
                 }
               : {
                   height: 91,
                   paddingTop: 20,
                   paddingHorizontal: 20,
+                  backgroundColor: colors.common.white,
                 },
           };
         }}
@@ -144,11 +148,13 @@ const CouncilMainTab = () => {
                   paddingTop: 20,
                   paddingHorizontal: 20,
                   marginBottom: 10,
+                  backgroundColor: colors.common.white,
                 }
               : {
                   height: 91,
                   paddingTop: 20,
                   paddingHorizontal: 20,
+                  backgroundColor: colors.common.white,
                 },
           };
         }}

--- a/src/components/MainTab.js
+++ b/src/components/MainTab.js
@@ -61,11 +61,13 @@ const MainTab = () => {
                 paddingTop: 20,
                 paddingHorizontal: 20,
                 marginBottom: 10,
+                backgroundColor: colors.common.white,
               }
             : {
                 height: 91,
                 paddingTop: 20,
                 paddingHorizontal: 20,
+                backgroundColor: colors.common.white,
               },
         tabBarItemStyle: { height: 51, width: 67, gap: 6 },
         tabBarLabelStyle: [
@@ -116,11 +118,13 @@ const MainTab = () => {
                   paddingTop: 20,
                   paddingHorizontal: 20,
                   marginBottom: 10,
+                  backgroundColor: colors.common.white,
                 }
               : {
                   height: 91,
                   paddingTop: 20,
                   paddingHorizontal: 20,
+                  backgroundColor: colors.common.white,
                 },
           };
         }}

--- a/src/constants/DummyData.js
+++ b/src/constants/DummyData.js
@@ -125,6 +125,14 @@ export const AFFILIATION_COLUMN_LIST_DATA_AFFILIATION = [
     detailImages: [],
     type: '제휴',
   },
+  {
+    title: '이탈리안 돈까스와 냉면 첫 방문 30% 할인',
+    place: '이탈리안 돈까스와 냉면 중앙대점',
+    date: '2025년 12월 1일까지',
+    image: null,
+    detailImages: [],
+    type: '제휴',
+  },
 ];
 
 // 행사 칼럼 리스트 전용 더미 데이터 (재상)

--- a/src/screens/Affiliation/AffiliationMainScreen.js
+++ b/src/screens/Affiliation/AffiliationMainScreen.js
@@ -4,13 +4,21 @@ import {
   StyleSheet,
   KeyboardAvoidingView,
   ScrollView,
+  FlatList,
+  Pressable,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import colors from '../../style/colors';
 import typography from '../../style/typography';
+import { useState } from 'react';
 import HostByTab from '../../components/Affiliation/HostByTab';
 import AffiliationCarousel from '../../components/Affiliation/AffiliationCarousel';
 import AffiliationColumnList from '../../components/Affiliation/AffiliationColumnList';
+import {
+  AFFILIATION_COLUMN_LIST_DATA_AFFILIATION,
+  AFFILIATION_COLUMN_LIST_DATA_EVENT,
+} from '../../constants/DummyData';
+import AffiliationColumnListItem from '../../components/Affiliation/AffiliationColumnListItem';
 
 const styles = StyleSheet.create({
   container: {
@@ -18,9 +26,43 @@ const styles = StyleSheet.create({
     backgroundColor: colors.common.white,
     alignItems: 'center',
   },
+  activityTypeSelector: {
+    width: '100%',
+    padding: 20,
+    flexDirection: 'row',
+    gap: 9,
+  },
+  activityTypeSelectorButton: {
+    borderRadius: 30,
+    borderWidth: 1.5,
+    borderColor: colors.gray[250],
+    width: 47,
+    height: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  activityTypeSelectorButtonText: {
+    ...typography.body4Regular,
+    color: colors.gray[700],
+  },
+  activityTypeSelectorButtonPressed: {
+    borderColor: colors.blue[400],
+  },
+  activityTypeSelectorOrangeButtonPressed: {
+    borderColor: colors.orange[400],
+  },
+  activityTypeSelectorOrangeButtonTextPressed: {
+    ...typography.body4Regular,
+    color: colors.orange[600],
+  },
+  activityTypeSelectorButtonTextPressed: {
+    ...typography.body4Regular,
+    color: colors.blue[600],
+  },
 });
 
 const AffiliationMainScreen = ({ navigation }) => {
+  const [selectedActivityType, setSelectedActivityType] = useState('제휴');
   return (
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <View style={{ marginTop: 9.5 }}>
@@ -31,7 +73,71 @@ const AffiliationMainScreen = ({ navigation }) => {
         />
       </View>
       <AffiliationCarousel />
-      <AffiliationColumnList navigation={navigation} />
+      {/* <AffiliationColumnList navigation={navigation} /> */}
+      <View style={styles.activityTypeSelector}>
+        <Pressable
+          style={[
+            styles.activityTypeSelectorButton,
+            selectedActivityType === '제휴'
+              ? styles.activityTypeSelectorButtonPressed
+              : styles.activityTypeSelectorButton,
+          ]}
+          onPress={() => setSelectedActivityType('제휴')}
+        >
+          <Text
+            style={
+              selectedActivityType === '제휴'
+                ? styles.activityTypeSelectorButtonTextPressed
+                : styles.activityTypeSelectorButtonText
+            }
+          >
+            제휴
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[
+            styles.activityTypeSelectorButton,
+            selectedActivityType === '행사'
+              ? styles.activityTypeSelectorButtonPressed
+              : styles.activityTypeSelectorButton,
+          ]}
+          onPress={() => setSelectedActivityType('행사')}
+        >
+          <Text
+            style={
+              selectedActivityType === '행사'
+                ? styles.activityTypeSelectorButtonTextPressed
+                : styles.activityTypeSelectorButtonText
+            }
+          >
+            행사
+          </Text>
+        </Pressable>
+      </View>
+      {selectedActivityType === '제휴' && (
+        <FlatList
+          style={{ width: '100%' }}
+          showsVerticalScrollIndicator={true}
+          contentContainerStyle={{ paddingHorizontal: 20 }}
+          data={AFFILIATION_COLUMN_LIST_DATA_AFFILIATION}
+          renderItem={({ item }) => (
+            <AffiliationColumnListItem item={item} navigation={navigation} />
+          )}
+          keyExtractor={(item) => item.id}
+        />
+      )}
+      {selectedActivityType === '행사' && (
+        <FlatList
+          style={{ width: '100%' }}
+          showsVerticalScrollIndicator={true}
+          contentContainerStyle={{ paddingHorizontal: 20 }}
+          data={AFFILIATION_COLUMN_LIST_DATA_EVENT}
+          renderItem={({ item }) => (
+            <AffiliationColumnListItem item={item} navigation={navigation} />
+          )}
+          keyExtractor={(item) => item.id}
+        />
+      )}
     </SafeAreaView>
   );
 };

--- a/src/screens/Affiliation/AffiliationMainScreen.js
+++ b/src/screens/Affiliation/AffiliationMainScreen.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
 
 const AffiliationMainScreen = ({ navigation }) => {
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <View style={{ marginTop: 9.5 }}>
         <HostByTab
           university={'중앙대학교'}

--- a/src/screens/Council/CouncilAffiliateScreen.js
+++ b/src/screens/Council/CouncilAffiliateScreen.js
@@ -105,6 +105,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.common.white,
     alignItems: 'center',
     position: 'relative',
+    paddingBottom: 40,
   },
   writeEventButton: {
     position: 'absolute',
@@ -149,6 +150,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   textInfoContainer: {
+    gap: 10,
     flexDirection: 'column',
   },
   councilIdentityNickname: {

--- a/src/screens/Council/CouncilAffiliateScreen.js
+++ b/src/screens/Council/CouncilAffiliateScreen.js
@@ -129,32 +129,37 @@ const CouncilAffiliateScreen = ({ navigation }) => {
             style={styles.writeEventTypeSelectorItem}
             onPress={() => {
               setIsWriteEventButtonPressed(false);
-              navigation.navigate('WriteEventPostScreen', {
-                type: 'event',
+              navigation.navigate('WriteAffiliatePostScreen', {
+                type: 'affiliate',
               });
             }}
           >
-            <EventSelectIcon
-              width={25}
-              height={25}
-              color={colors.orange[500]}
-            />
+            <View style={{ marginTop: -3 }}>
+              <AffiliateSelectIcon width={25} height={25} />
+            </View>
             <Text style={styles.writeEventTypeSelectorItemText}>
-              행사 글쓰기
+              제휴 글쓰기
             </Text>
           </Pressable>
           <Pressable
             style={styles.writeEventTypeSelectorItem}
             onPress={() => {
               setIsWriteEventButtonPressed(false);
-              navigation.navigate('WriteAffiliatePostScreen', {
-                type: 'affiliate',
+              navigation.navigate('WriteEventPostScreen', {
+                type: 'event',
               });
             }}
           >
-            <AffiliateSelectIcon width={25} height={25} />
+            <View style={{ marginTop: -3 }}>
+              <EventSelectIcon
+                width={25}
+                height={25}
+                color={colors.orange[500]}
+              />
+            </View>
+
             <Text style={styles.writeEventTypeSelectorItemText}>
-              제휴 글쓰기
+              행사 글쓰기
             </Text>
           </Pressable>
         </View>
@@ -206,7 +211,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   writeEventTypeSelectorItem: {
-    width: '100%',
+    width: 163,
+    height: 25,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start',

--- a/src/screens/Council/CouncilAffiliateScreen.js
+++ b/src/screens/Council/CouncilAffiliateScreen.js
@@ -105,7 +105,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.common.white,
     alignItems: 'center',
     position: 'relative',
-    paddingBottom: 40,
   },
   writeEventButton: {
     position: 'absolute',

--- a/src/screens/Council/CouncilAffiliateScreen.js
+++ b/src/screens/Council/CouncilAffiliateScreen.js
@@ -6,6 +6,7 @@ import {
   ScrollView,
   Pressable,
   Image,
+  FlatList,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import colors from '../../style/colors';
@@ -20,8 +21,14 @@ import EventSelectIcon from '../../../assets/mdi_event.svg';
 import AffiliateSelectIcon from '../../../assets/supportIcon.svg';
 import CouncilDefaultImage from '../../../assets/councilDefaultImage.png';
 import useAuthStore from '../../store/authStore';
+import AffiliationColumnListItem from '../../components/Affiliation/AffiliationColumnListItem';
+import {
+  AFFILIATION_COLUMN_LIST_DATA_AFFILIATION,
+  AFFILIATION_COLUMN_LIST_DATA_EVENT,
+} from '../../constants/DummyData';
 
 const CouncilAffiliateScreen = ({ navigation }) => {
+  const [selectedActivityType, setSelectedActivityType] = useState('제휴');
   const { user } = useAuthStore();
   console.log(user);
   const [isWriteEventButtonPressed, setIsWriteEventButtonPressed] =
@@ -49,7 +56,73 @@ const CouncilAffiliateScreen = ({ navigation }) => {
         </View>
       </View>
       <AffiliationCarousel isOrange={true} />
-      <AffiliationColumnList navigation={navigation} isOrange={true} />
+
+      <View style={styles.activityTypeSelector}>
+        <Pressable
+          style={[
+            styles.activityTypeSelectorButton,
+            selectedActivityType === '제휴'
+              ? styles.activityTypeSelectorOrangeButtonPressed
+              : styles.activityTypeSelectorButton,
+          ]}
+          onPress={() => setSelectedActivityType('제휴')}
+        >
+          <Text
+            style={
+              selectedActivityType === '제휴'
+                ? styles.activityTypeSelectorOrangeButtonTextPressed
+                : styles.activityTypeSelectorButtonText
+            }
+          >
+            제휴
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[
+            styles.activityTypeSelectorButton,
+            selectedActivityType === '행사'
+              ? styles.activityTypeSelectorOrangeButtonPressed
+              : styles.activityTypeSelectorButton,
+          ]}
+          onPress={() => setSelectedActivityType('행사')}
+        >
+          <Text
+            style={
+              selectedActivityType === '행사'
+                ? styles.activityTypeSelectorOrangeButtonTextPressed
+                : styles.activityTypeSelectorButtonText
+            }
+          >
+            행사
+          </Text>
+        </Pressable>
+      </View>
+      {selectedActivityType === '제휴' && (
+        <FlatList
+          style={{ width: '100%' }}
+          showsVerticalScrollIndicator={true}
+          contentContainerStyle={{ paddingHorizontal: 20 }}
+          data={AFFILIATION_COLUMN_LIST_DATA_AFFILIATION}
+          renderItem={({ item }) => (
+            <AffiliationColumnListItem item={item} navigation={navigation} />
+          )}
+          keyExtractor={(item) => item.id}
+        />
+      )}
+      {selectedActivityType === '행사' && (
+        <FlatList
+          style={{ width: '100%' }}
+          showsVerticalScrollIndicator={true}
+          contentContainerStyle={{ paddingHorizontal: 20 }}
+          data={AFFILIATION_COLUMN_LIST_DATA_EVENT}
+          renderItem={({ item }) => (
+            <AffiliationColumnListItem item={item} navigation={navigation} />
+          )}
+          keyExtractor={(item) => item.id}
+        />
+      )}
+
+      {/* <AffiliationColumnList navigation={navigation} isOrange={true} /> */}
       {isWriteEventButtonPressed && (
         <View style={styles.writeEventTypeSelector}>
           <Pressable
@@ -170,6 +243,39 @@ const styles = StyleSheet.create({
   councilIdentityImage: {
     width: '100%',
     height: '100%',
+  },
+  activityTypeSelector: {
+    width: '100%',
+    padding: 20,
+    flexDirection: 'row',
+    gap: 9,
+  },
+  activityTypeSelectorButton: {
+    borderRadius: 30,
+    borderWidth: 1.5,
+    borderColor: colors.gray[250],
+    width: 47,
+    height: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  activityTypeSelectorButtonText: {
+    ...typography.body4Regular,
+    color: colors.gray[700],
+  },
+  activityTypeSelectorButtonPressed: {
+    borderColor: colors.blue[400],
+  },
+  activityTypeSelectorOrangeButtonPressed: {
+    borderColor: colors.orange[400],
+  },
+  activityTypeSelectorOrangeButtonTextPressed: {
+    ...typography.body4Regular,
+    color: colors.orange[600],
+  },
+  activityTypeSelectorButtonTextPressed: {
+    ...typography.body4Regular,
+    color: colors.blue[600],
   },
 });
 

--- a/src/screens/Council/MyPage/CouncilMyPageDefaultScreen.js
+++ b/src/screens/Council/MyPage/CouncilMyPageDefaultScreen.js
@@ -32,14 +32,13 @@ const CouncilMyPageDefaultScreen = ({ navigation }) => {
           계정관리
         </Text>
         <View style={styles.customerServiceItemWrapper}>
-          <View style={styles.customerServiceItem}>
+          <Pressable
+            style={styles.customerServiceItem}
+            onPress={() => navigation.navigate('CouncilProfileScreen')}
+          >
             <Text style={styles.customerServiceItemText}>내 계정</Text>
-            <Pressable
-              onPress={() => navigation.navigate('CouncilProfileScreen')}
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
         </View>
         <Text
           style={{
@@ -51,20 +50,20 @@ const CouncilMyPageDefaultScreen = ({ navigation }) => {
           고객 센터
         </Text>
         <View style={styles.customerServiceItemWrapper}>
-          <View style={styles.customerServiceItem}>
+          <Pressable
+            style={styles.customerServiceItem}
+            onPress={() => navigation.navigate('AnnouncementScreen')}
+          >
             <Text style={styles.customerServiceItemText}>공지사항</Text>
-            <Pressable
-              onPress={() => navigation.navigate('AnnouncementScreen')}
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
-          <View style={styles.customerServiceItem}>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
+          <Pressable
+            style={styles.customerServiceItem}
+            onPress={() => navigation.navigate('InqueryMainScreen')}
+          >
             <Text style={styles.customerServiceItemText}>1:1 문의게시판</Text>
-            <Pressable onPress={() => navigation.navigate('InqueryMainScreen')}>
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
         </View>
       </View>
     </SafeAreaView>
@@ -139,6 +138,7 @@ const styles = StyleSheet.create({
   },
   textInfoContainer: {
     flexDirection: 'column',
+    gap: 10,
   },
   councilIdentityNickname: {
     ...typography.heading4,

--- a/src/screens/Council/MyPage/CouncilProfileScreen.js
+++ b/src/screens/Council/MyPage/CouncilProfileScreen.js
@@ -86,33 +86,27 @@ const CouncilProfileScreen = ({ navigation, route }) => {
           <Text style={{ ...typography.body4Bold, color: colors.gray[400] }}>
             계정 보안
           </Text>
-          <View style={styles.profileInfoItem}>
+          <Pressable
+            style={styles.profileInfoItem}
+            onPress={() => navigation.navigate('CouncilChangePasswordEmail')}
+          >
             <Text style={styles.profileInfoItemTitle}>비밀번호 변경</Text>
-            <Pressable
-              onPress={() => navigation.navigate('CouncilChangePasswordEmail')}
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
-          <View
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
+          <Pressable
             style={styles.profileInfoItem}
             onPress={() => setIsLogoutModalVisible(true)}
           >
             <Text style={styles.profileInfoItemTitle}>로그아웃</Text>
-            <Pressable onPress={() => setIsLogoutModalVisible(true)}>
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
-          <View style={styles.profileInfoItem}>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
+          <Pressable
+            style={styles.profileInfoItem}
+            onPress={() => navigation.navigate('CouncilCancelMembershipScreen')}
+          >
             <Text style={styles.profileInfoItemTitle}>탈퇴하기</Text>
-            <Pressable
-              onPress={() =>
-                navigation.navigate('CouncilCancelMembershipScreen')
-              }
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
         </View>
       </SafeAreaView>
       <Modal

--- a/src/screens/Home/HomeScreen.js
+++ b/src/screens/Home/HomeScreen.js
@@ -37,7 +37,7 @@ const HomeScreen = () => {
   const [hasNewNotification, setHasNewNotification] = useState(true);
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <ScrollView style={styles.container}>
         {/* 행사 안내 */}
         <View style={styles.topArea}>

--- a/src/screens/MyPage/MyPageDefaultScreen.js
+++ b/src/screens/MyPage/MyPageDefaultScreen.js
@@ -66,20 +66,20 @@ const MyPageDefaultScreen = ({ navigation }) => {
           고객센터
         </Text>
         <View style={styles.customerServiceItemWrapper}>
-          <View style={styles.customerServiceItem}>
+          <Pressable
+            style={styles.customerServiceItem}
+            onPress={() => navigation.navigate('AnnouncementScreen')}
+          >
             <Text style={styles.customerServiceItemText}>공지사항</Text>
-            <Pressable
-              onPress={() => navigation.navigate('AnnouncementScreen')}
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
-          <View style={styles.customerServiceItem}>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
+          <Pressable
+            style={styles.customerServiceItem}
+            onPress={() => navigation.navigate('InqueryMainScreen')}
+          >
             <Text style={styles.customerServiceItemText}>1:1 문의게시판</Text>
-            <Pressable onPress={() => navigation.navigate('InqueryMainScreen')}>
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
         </View>
       </View>
     </SafeAreaView>

--- a/src/screens/MyPage/MyPageProfileEditScreen.js
+++ b/src/screens/MyPage/MyPageProfileEditScreen.js
@@ -28,14 +28,13 @@ const MyPageProfileEditScreen = ({ navigation }) => {
         </View>
         <Text style={styles.nickname}>닉넴 뭐하지</Text>
         <View style={styles.profileInfoWrapper}>
-          <View style={styles.profileInfoItem}>
+          <Pressable
+            style={styles.profileInfoItem}
+            onPress={() => navigation.navigate('EditNicknameScreen')}
+          >
             <Text style={styles.profileInfoItemTitle}>닉네임</Text>
-            <Pressable
-              onPress={() => navigation.navigate('EditNicknameScreen')}
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
           <View style={styles.profileInfoItem}>
             <Text style={styles.profileInfoItemTitle}>학적정보</Text>
             <ArrowRightIcon width={10} height={10} />
@@ -53,23 +52,20 @@ const MyPageProfileEditScreen = ({ navigation }) => {
           </View>
         </View>
         <View style={styles.logoutButtonWrapper}>
-          <View
+          <Pressable
             style={styles.profileInfoItem}
             onPress={() => setIsLogoutModalVisible(true)}
           >
             <Text style={styles.profileInfoItemTitle}>로그아웃</Text>
-            <Pressable onPress={() => setIsLogoutModalVisible(true)}>
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
-          <View style={styles.profileInfoItem}>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
+          <Pressable
+            style={styles.profileInfoItem}
+            onPress={() => navigation.navigate('CancelMembershipScreen')}
+          >
             <Text style={styles.profileInfoItemTitle}>회원 탈퇴</Text>
-            <Pressable
-              onPress={() => navigation.navigate('CancelMembershipScreen')}
-            >
-              <ArrowRightIcon width={10} height={10} />
-            </Pressable>
-          </View>
+            <ArrowRightIcon width={10} height={10} />
+          </Pressable>
         </View>
       </SafeAreaView>
       <Modal


### PR DESCRIPTION
## 📌 관련 이슈
close #35 

## ✨ 변경 사항
> 주요 변경 내용 요약
받은 피드백 요청에 따라 스타일 수정 


## 🧩 세부 내용
- 카루셀 아이템 첫 아이템 과 마지막 아이템에만 padding 여백 보이게 설정
- 제휴 아이템 ui 크기 확대 
- 제휴/행사 스위치 탭 글씨체 변경 현상 수정
- ios 전용 메인탭 상단 여백 제거
- 제휴 아이템 왼쪽 정렬 
- 학생회 글쓰기 선택 탭 범위 확대 
- 마이페이지 ui 범위 확대 


## 📸 스크린샷 (선택)
<img width="240" alt="Simulator Screenshot - iPhone 16 Pro - 2026-01-10 at 16 31 57" src="https://github.com/user-attachments/assets/a99a27c1-f9cc-41b4-8758-9c61dbcdd5a0" />
<img width="240"  alt="Simulator Screenshot - iPhone 16 Pro - 2026-01-10 at 16 32 46" src="https://github.com/user-attachments/assets/2fb8b264-f4fe-4539-b091-f23d83c7bf68" />


## 💬 기타 참고사항
> 리뷰어가 알아야 할 추가 내용
<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
