### PR TITLE
[Refactor]: 로그인/온보딩 디자인 수정

### DIFF
--- a/src/screens/SignUp/StudentCouncil/SignUpRepresentativeScreen.js
+++ b/src/screens/SignUp/StudentCouncil/SignUpRepresentativeScreen.js
@@ -312,11 +312,15 @@ const SignUpRepresentativeScreen = ({ navigation }) => {
               </View>
             </View>
             <View>
+              <View style={styles.emailTitleRow}>
+                <Text style={styles.emailTitle}>학교 이메일</Text>
+                <Text style={styles.emailCaption}>
+                  *중앙대학교 이메일(@cau.ac.kr)만 입력 가능
+                </Text>
+              </View>
               <Input
                 isOrange={true}
                 ref={emailInputRef}
-                title="학교 이메일"
-                useTitle={true}
                 useEmail={true}
                 placeholder="메일주소를 입력해주세요"
                 useMagnifyingGlass={false}
@@ -431,6 +435,20 @@ const styles = StyleSheet.create({
     textDecorationLine: 'underline',
     marginTop: 24,
     marginBottom: 12,
+  },
+  emailTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10,
+    gap: 4,
+  },
+  emailTitle: {
+    ...typography.body3Bold,
+    color: colors.gray[850],
+  },
+  emailCaption: {
+    ...typography.caption2Regular,
+    color: colors.gray[400],
   },
   userIdStatusText: {
     fontSize: 12,

--- a/src/screens/SignUp/StudentCouncil/WriteRepresentativeInfo1.js
+++ b/src/screens/SignUp/StudentCouncil/WriteRepresentativeInfo1.js
@@ -21,9 +21,12 @@ import { Image } from 'react-native';
 import MajorInputModal from '../../../components/majorInputModal';
 import CollegeInputModal from '../../../components/CollegeInputModal';
 import { searchUniversity } from '../../../api/signUp';
-import { searchMajor } from '../../../api/signUp';
-import { searchCollege } from '../../../api/signUp';
-import UniversityInputModal from '../../../components/UniversityInputModal';
+// TODO: 학교 선택 기능 재오픈 시 주석 해제
+// import { searchMajor } from '../../../api/signUp';
+// import { searchCollege } from '../../../api/signUp';
+// import UniversityInputModal from '../../../components/UniversityInputModal';
+
+const FIXED_UNIVERSITY_NAME = '중앙대학교 서울캠퍼스';
 
 const WriteRepresentativeInfo1 = ({ navigation, route }) => {
   const email = route.params?.email;
@@ -37,27 +40,44 @@ const WriteRepresentativeInfo1 = ({ navigation, route }) => {
     useState(false);
   const [isCollegeInputModalVisible, setIsCollegeInputModalVisible] =
     useState(false);
-  const [isUniversityInputModalVisible, setIsUniversityInputModalVisible] =
-    useState(false);
-  const [major, setMajor] = useState(null); // 학과
-  const [majorId, setMajorId] = useState(null); // 학과 ID
-  const [college, setCollege] = useState(null); // 단과대학
-  const [collegeId, setCollegeId] = useState(null); // 단과대학 ID
-  const [university, setUniversity] = useState(null); // 학교명
-  const [universityId, setUniversityId] = useState(null); // 학교 ID
-  const [finalData, setFinalData] = useState(null); // 최종 데이터
+  // TODO: 학교 선택 기능 재오픈 시 주석 해제
+  // const [isUniversityInputModalVisible, setIsUniversityInputModalVisible] =
+  //   useState(false);
+  const [major, setMajor] = useState(null);
+  const [majorId, setMajorId] = useState(null);
+  const [college, setCollege] = useState(null);
+  const [collegeId, setCollegeId] = useState(null);
+  // TODO: 학교 선택 기능 재오픈 시 주석 해제 후 고정값 제거
+  // const [university, setUniversity] = useState(null);
+  const [universityId, setUniversityId] = useState(null);
+  const [finalData, setFinalData] = useState(null);
+
+  // 마운트 시 중앙대학교 schoolId 자동 조회
+  useEffect(() => {
+    const fetchUniversityId = async () => {
+      try {
+        const result = await searchUniversity('중앙대학교');
+        if (result && result.length > 0) {
+          setUniversityId(result[0].schoolId);
+        }
+      } catch (error) {
+        console.error('학교 ID 조회 실패:', error);
+      }
+    };
+    fetchUniversityId();
+  }, []);
 
   useEffect(() => {
-    if (selectedValue == 'total' && university) {
+    if (selectedValue == 'total' && universityId) {
       setIsButtonDisabled(false);
-    } else if (selectedValue == 'college' && college && university) {
+    } else if (selectedValue == 'college' && college && universityId) {
       setIsButtonDisabled(false);
-    } else if (selectedValue == 'major' && major && college && university) {
+    } else if (selectedValue == 'major' && major && universityId) {
       setIsButtonDisabled(false);
     } else {
       setIsButtonDisabled(true);
     }
-  }, [selectedValue, major, college, university]);
+  }, [selectedValue, major, college, universityId]);
 
   const handleNextButtonPress = () => {
     let councilType = '';
@@ -97,7 +117,7 @@ const WriteRepresentativeInfo1 = ({ navigation, route }) => {
       >
         <StatusBar style="auto" />
         <LabelTitle
-          title="회원가입"
+          title="학교/학과 선택"
           useBackButton={true}
           onPressBack={() => navigation?.goBack()}
           navigation={navigation}
@@ -123,12 +143,14 @@ const WriteRepresentativeInfo1 = ({ navigation, route }) => {
                 title="학교"
                 placeholder="학교 이름을 입력해주세요"
                 useTitle={true}
-                useMagnifyingGlass={true}
-                usePopUPModal={true}
-                value={university || ''}
-                onPressPopUPModal={() => {
-                  setIsUniversityInputModalVisible(true);
-                }}
+                value={FIXED_UNIVERSITY_NAME}
+                onlyRead={true}
+                // TODO: 학교 선택 기능 재오픈 시 아래 주석 해제 + onlyRead 제거 + value={university}
+                // useMagnifyingGlass={true}
+                // usePopUPModal={true}
+                // onPressPopUPModal={() => {
+                //   setIsUniversityInputModalVisible(true);
+                // }}
               />
               <Text style={styles.toggleTitle}>소속 단위</Text>
               <View style={styles.toggleContainer}>
@@ -178,7 +200,7 @@ const WriteRepresentativeInfo1 = ({ navigation, route }) => {
                       <UnselectedRadioButton width={18} height={18} />
                     )}
                   </Pressable>
-                  <Text style={styles.toggleItemText}>단과대학 총학생회</Text>
+                  <Text style={styles.toggleItemText}>단과대학 학생회</Text>
                 </View>
                 <View style={styles.toggleItem}>
                   <Pressable
@@ -292,7 +314,8 @@ const WriteRepresentativeInfo1 = ({ navigation, route }) => {
           }}
         />
       )}
-      {isUniversityInputModalVisible && (
+      {/* TODO: 학교 선택 기능 재오픈 시 주석 해제 */}
+      {/* {isUniversityInputModalVisible && (
         <UniversityInputModal
           isOrange={true}
           onClose={() => setIsUniversityInputModalVisible(false)}
@@ -302,7 +325,7 @@ const WriteRepresentativeInfo1 = ({ navigation, route }) => {
             setIsUniversityInputModalVisible(false);
           }}
         />
-      )}
+      )} */}
     </SafeAreaView>
   );
 };

--- a/src/screens/SignUp/StudentSignUp/SignUpFirstScreen.js
+++ b/src/screens/SignUp/StudentSignUp/SignUpFirstScreen.js
@@ -8,22 +8,41 @@ import typography from '../../../style/typography';
 import { useState, useEffect } from 'react';
 import MajorInputModal from '../../../components/majorInputModal';
 import Button from '../../../components/Button';
-import UniversityInputModal from '../../../components/UniversityInputModal';
-import { searchCollege } from '../../../api/signUp';
-import { sendUserProfile } from '../../../api/signUp';
+// TODO: 학교 선택 기능 재오픈 시 주석 해제
+// import UniversityInputModal from '../../../components/UniversityInputModal';
+import { searchUniversity, sendUserProfile } from '../../../api/signUp';
+
+const FIXED_UNIVERSITY_NAME = '중앙대학교 서울캠퍼스';
 
 const SignUpFirstScreen = ({ navigation, route }) => {
   const [isMajorInputModalVisible, setIsMajorInputModalVisible] =
     useState(false);
-  const [isUniversityInputModalVisible, setIsUniversityInputModalVisible] =
-    useState(false);
+  // TODO: 학교 선택 기능 재오픈 시 주석 해제
+  // const [isUniversityInputModalVisible, setIsUniversityInputModalVisible] =
+  //   useState(false);
   const [major, setMajor] = useState(null);
   const [majorId, setMajorId] = useState(null);
-  const [university, setUniversity] = useState(null);
+  // TODO: 학교 선택 기능 재오픈 시 주석 해제 후 고정값 제거
+  // const [university, setUniversity] = useState(null);
   const [universityId, setUniversityId] = useState(null);
   const [department, setDepartment] = useState(null);
-  const [departmentId, setDepartmentId] = useState(null);
+  // const [departmentId, setDepartmentId] = useState(null);
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+
+  // 마운트 시 중앙대학교 schoolId 자동 조회
+  useEffect(() => {
+    const fetchUniversityId = async () => {
+      try {
+        const result = await searchUniversity('중앙대학교');
+        if (result && result.length > 0) {
+          setUniversityId(result[0].schoolId);
+        }
+      } catch (error) {
+        console.error('학교 ID 조회 실패:', error);
+      }
+    };
+    fetchUniversityId();
+  }, []);
 
   useEffect(() => {
     const keyboardDidShowListener = Keyboard.addListener(
@@ -45,21 +64,13 @@ const SignUpFirstScreen = ({ navigation, route }) => {
     };
   }, []);
 
-  const matchCollege = async (schoolId, majorName) => {
-    console.log('matchCollege called');
-    console.log('schoolId:', schoolId);
-    console.log('majorName:', majorName);
-    const result = await searchCollege(schoolId, majorName);
-    console.log('✅ Match College Response:', result);
-  };
-
   const handleFinalSignUpSubmit = async () => {
     const result = await sendUserProfile(universityId, majorId);
     console.log('✅ Final Sign Up Submit Response:', result);
     if (result) {
       navigation.navigate('SignUpSecondScreen', {
         userName: route.params?.userName,
-        university: university,
+        university: FIXED_UNIVERSITY_NAME,
         department: department,
         major: major,
       });
@@ -107,21 +118,24 @@ const SignUpFirstScreen = ({ navigation, route }) => {
               title="학교"
               useTitle={true}
               placeholder="학교 이름을 입력해주세요"
-              useMagnifyingGlass={true}
-              value={university}
-              usePopUPModal={true}
-              onPressPopUPModal={() => {
-                setIsUniversityInputModalVisible(true);
-              }}
+              value={FIXED_UNIVERSITY_NAME}
+              onlyRead={true}
+            // TODO: 학교 선택 기능 재오픈 시 아래 주석 해제 + onlyRead 제거 + value={university}
+            // useMagnifyingGlass={true}
+            // usePopUPModal={true}
+            // onPressPopUPModal={() => {
+            //   setIsUniversityInputModalVisible(true);
+            // }}
             />
-            <Input
+            {/* TODO: 학교 선택 기능 재오픈 시 단과대 필드 주석 해제 */}
+            {/* <Input
               title="단과 대학"
               useTitle={true}
               placeholder="학과 선택시 자동으로 입력됩니다"
               value={department || ''}
               disabled={true}
               additionalStyle={{ backgroundColor: colors.gray[250] }}
-            />
+            /> */}
             <Input
               title="학과"
               useTitle={true}
@@ -132,9 +146,9 @@ const SignUpFirstScreen = ({ navigation, route }) => {
               onPressPopUPModal={() => {
                 setIsMajorInputModalVisible(true);
               }}
-              disabled={university === '' || universityId === null}
+              disabled={universityId === null}
               additionalStyle={
-                university === '' || universityId === null
+                universityId === null
                   ? { backgroundColor: colors.gray[250] }
                   : {}
               }
@@ -148,18 +162,8 @@ const SignUpFirstScreen = ({ navigation, route }) => {
           >
             <Button
               title="다음"
-              disabled={!university || !major || !department}
-              onPress={
-                () => handleFinalSignUpSubmit()
-                // navigation.navigate('SignUpSecondScreen', {
-                //   userName: route.params?.userName,
-                //   university: university,
-                //   department: department,
-                //   major: major,
-                //   universityId: universityId,
-                //   majorId: majorId,
-                // })
-              }
+              disabled={!major || !universityId}
+              onPress={() => handleFinalSignUpSubmit()}
               style={styles.button}
             />
           </View>
@@ -173,12 +177,13 @@ const SignUpFirstScreen = ({ navigation, route }) => {
             setMajor(selectedMajor.majorName);
             setMajorId(selectedMajor.majorId);
             setDepartment(selectedMajor.collegeName);
-            setDepartmentId(selectedMajor.collegeId);
+            // setDepartmentId(selectedMajor.collegeId);
             setIsMajorInputModalVisible(false);
           }}
         />
       )}
-      {isUniversityInputModalVisible && (
+      {/* TODO: 학교 선택 기능 재오픈 시 주석 해제 */}
+      {/* {isUniversityInputModalVisible && (
         <UniversityInputModal
           onClose={() => setIsUniversityInputModalVisible(false)}
           onSelect={(selectedUniversity) => {
@@ -188,7 +193,7 @@ const SignUpFirstScreen = ({ navigation, route }) => {
             setIsUniversityInputModalVisible(false);
           }}
         />
-      )}
+      )} */}
     </>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈

close #62 

## ✨ 변경 사항

서비스 지역이 중앙대학교 서울캠퍼스로 고정됨에 따라 발생한 디자인 수정 반영

## 🧩 세부 내용

- [x] 중앙대 메일 주소로만 가입 가능하다는 캡션 추가
- [x] 학교 입력값 '중앙대학교 서울캠퍼스'로 다 고정된 디자인으로 수정

## 📸 스크린샷

<img width="357" height="817" alt="Screenshot 2026-02-15 104535" src="https://github.com/user-attachments/assets/0dcca1e4-f5b1-4dbf-afa7-35a694cf0b34" />
<img width="355" height="819" alt="Screenshot 2026-02-15 104701" src="https://github.com/user-attachments/assets/1c50f271-9cc9-4a26-a622-fd771acc5556" />
<img width="356" height="820" alt="Screenshot 2026-02-15 104848" src="https://github.com/user-attachments/assets/4e1acc89-6cdb-4415-80a2-5422d617134d" />
<img width="358" height="819" alt="Screenshot 2026-02-15 105035" src="https://github.com/user-attachments/assets/c1dbb4a0-bd09-451e-95f1-dbd701ba554b" />
<img width="356" height="817" alt="Screenshot 2026-02-15 105100" src="https://github.com/user-attachments/assets/e4dc07cb-f7ac-4ccc-9c88-2ec26289262f" />

