### PR TITLE
[Feature]: 스탬프, 운영 리포트 준비 중 화면

### DIFF
--- a/src/components/CouncilMainTab.js
+++ b/src/components/CouncilMainTab.js
@@ -1,12 +1,10 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { getFocusedRouteNameFromRoute } from '@react-navigation/native';
-import { View, Text, Keyboard } from 'react-native';
 import { Platform } from 'react-native';
 
 import HomeIcon from '../../assets/Vector1.svg';
 import MapIcon from '../../assets/Vector2.svg';
 import PartnershipIcon from '../../assets/Vector3.svg';
-import StampIcon from '../../assets/Vector4.svg';
 import MyPageIcon from '../../assets/Vector5.svg';
 import ReportIcon from '../../assets/report.svg';
 
@@ -24,13 +22,7 @@ import CouncilMainPageStack from '../navigations/Council/CouncilMainPageStack';
 
 const Tab = createBottomTabNavigator();
 
-const PlaceholderScreen = () => {
-  return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>PlaceholderScreen</Text>
-    </View>
-  );
-};
+import WIPScreen from './common/WIPScreen';
 
 const ICONS = {
   Home: HomeIcon,
@@ -128,7 +120,7 @@ const CouncilMainTab = () => {
       />
       <Tab.Screen
         name="Report"
-        component={PlaceholderScreen}
+        component={WIPScreen}
         options={{ title: '운영리포트' }}
       />
       <Tab.Screen

--- a/src/components/MainTab.js
+++ b/src/components/MainTab.js
@@ -17,7 +17,7 @@ import MapScreen from '../screens/Map/MapScreen';
 import AffiliationSelectStack from '../navigations/AffiliationSelectStack';
 import MapStack from '../navigations/MapStack';
 import MyPageStack from '../navigations/MyPageStack';
-import StampStack from '../navigations/StampStack';
+import WIPScreen from './common/WIPScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -118,7 +118,7 @@ const MainTab = () => {
       />
       <Tab.Screen
         name="Stamp"
-        component={StampStack}
+        component={WIPScreen}
         options={{ title: '스탬프' }}
       />
       <Tab.Screen

--- a/src/components/common/WIPScreen.js
+++ b/src/components/common/WIPScreen.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+
+import WarningIcon from '@assets/icons/warning-line.svg';
+import colors from '@style/colors';
+import typography from '@style/typography';
+
+const WIPScreen = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <WarningIcon width={56} height={56} />
+        <View style={styles.textContainer}>
+          <Text style={styles.title}>{'서비스 준비중입니다. '}</Text>
+          <Text style={styles.description}>
+            {'이용에 불편을 드려 죄송합니다. \n'}
+            {'보다 나은 서비스 제공을 위해 페이지 준비중에 있습니다.\n'}
+            {'빠른시일내에 준비하여 찾아뵙겠습니다. '}
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.common.white,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 20,
+  },
+  textContainer: {
+    gap: 4,
+    alignItems: 'center',
+  },
+  title: {
+    ...typography.heading4,
+    color: colors.gray[400],
+    textAlign: 'center',
+  },
+  description: {
+    ...typography.body4Regular,
+    color: colors.gray[300],
+    textAlign: 'center',
+  },
+});
+
+export default WIPScreen;


### PR DESCRIPTION
## 📌 관련 이슈

close #71 

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

출시 MVP 이외의 기능 사용 제한을 위한 준비 중 화면 도입

<!-- 어떤 기능을 추가/수정했는지 간단히 설명 -->

## 🧩 세부 내용

- [x] 스탬프 화면 준비 중 화면으로 제한
- [x] 운영 리포트 화면 준비 중 화면으로 제한

## 📸 스크린샷 (선택)
<img width="412" height="912" alt="image" src="https://github.com/user-attachments/assets/87c6841c-1105-44c7-8e19-7d99374b934f" />
<img width="408" height="910" alt="image" src="https://github.com/user-attachments/assets/b8898f2b-ac5b-4f6d-8003-dc26519b025e" />


