### PR TITLE
[Refactor]: 지도뷰 매장 바텀시트 디자인 수정

### DIFF
--- a/src/api/place.js
+++ b/src/api/place.js
@@ -261,11 +261,13 @@ export const togglePlaceLike = async (placeData) => {
       },
     });
 
-    console.log('서버 응답:', response.data);
-    return response.data;
+    if (response.data.code === 200 || response.data.code === 0) {
+      return response.data.data;
+    }
+    return false;
   } catch (error) {
     console.error('좋아요 요청 실패:', error);
-    throw error;
+    return false;
   }
 };
 

--- a/src/components/common/StoreListItem.js
+++ b/src/components/common/StoreListItem.js
@@ -252,4 +252,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default StoreListItem;
+export default React.memo(StoreListItem);

--- a/src/components/common/StoreListItem.js
+++ b/src/components/common/StoreListItem.js
@@ -31,12 +31,14 @@ const StoreListItem = ({
     setIsLiked(!isLiked);
 
     try {
-      const response = await togglePlaceLike(item);
+      const responseData = await togglePlaceLike(item);
 
-      console.log('👍 좋아요 응답:', response);
-      const responseData = response.data || response;
+      if (!responseData) {
+        setIsLiked(previousState);
+        return;
+      }
 
-      if (responseData && responseData.placeId) {
+      if (responseData.placeId) {
         if (onLikeToggle) {
           onLikeToggle(item.placeId, {
             placeId: responseData.placeId,

--- a/src/components/common/StoreListItem.js
+++ b/src/components/common/StoreListItem.js
@@ -12,6 +12,7 @@ import LikedIcon from '../../../assets/Liked.svg';
 import UnlikedIcon from '../../../assets/Unliked.svg';
 
 import { togglePlaceLike } from '../../api/place';
+import { formatDistance, calculateWalkingTime } from '../../utils/distance';
 
 const StoreListItem = ({
   item,
@@ -143,10 +144,11 @@ const StoreListItem = ({
                     height={20}
                     style={styles.iconMargin}
                   />
-                  <Text style={styles.infoText}>{item.address}</Text>
+                  <Text style={styles.infoText}>
+                    걸어서 {calculateWalkingTime(item.distance)}분
+                  </Text>
                   <Text style={styles.distanceText}>
-                    {' '}
-                    {item.distance}
+                    {formatDistance(item.distance)}
                   </Text>
                 </View>
               </>
@@ -241,10 +243,17 @@ const styles = StyleSheet.create({
   infoText: {
     ...typography.body4Regular,
     color: theme.colors.textDim,
+    includeFontPadding: false,
+    textAlignVertical: 'center',
   },
   distanceText: {
     ...typography.caption1Regular,
+    lineHeight: typography.body4Regular.lineHeight,
     color: colors.gray[400],
+    includeFontPadding: false,
+    textAlignVertical: 'center',
+    marginLeft: 4,
+    transform: [{translateY: 1}],
   },
   thumbnail: {
     width: 68,

--- a/src/components/common/StoreListItem.js
+++ b/src/components/common/StoreListItem.js
@@ -1,13 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ScrollView,
-  Image,
-} from 'react-native';
+import { View, Text, StyleSheet, Pressable, Image } from 'react-native';
 import theme from '../../style';
+import colors from '../../style/colors';
 import typography from '../../style/typography';
 
 import StarIcon from '../../../assets/icons/common/star.svg';
@@ -37,7 +31,6 @@ const StoreListItem = ({
     setIsLiked(!isLiked);
 
     try {
-      // 2. 서버 요청
       const response = await togglePlaceLike(item);
 
       console.log('👍 좋아요 응답:', response);
@@ -58,7 +51,8 @@ const StoreListItem = ({
   };
 
   const categoryLabel =
-    CATEGORIES.find((cat) => cat.id === item.category)?.label || item.category;
+    CATEGORIES.find((cat) => cat.id === item.category)?.label ||
+    item.category;
 
   const tags = [];
   if (item.tag) tags.push(item.tag);
@@ -67,23 +61,30 @@ const StoreListItem = ({
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity onPress={onPress} activeOpacity={0.9}>
+      <Pressable
+        testID="store-list-item-pressable"
+        onPress={onPress}
+      >
         <View style={styles.headerRow}>
           <View style={styles.titleWrapper}>
             <Text style={styles.name}>{item.name}</Text>
             <Text style={styles.category}>{categoryLabel}</Text>
           </View>
-          <TouchableOpacity
+          <Pressable
+            testID="store-like-button"
             style={styles.likeButton}
             onPress={handleLikePress}
-            activeOpacity={0.7}
           >
             {isLiked ? (
-              <LikedIcon width={16} height={15} color={theme.colors.primary2} />
+              <LikedIcon
+                width={12}
+                height={11}
+                color={theme.colors.primary2}
+              />
             ) : (
-              <UnlikedIcon width={16} height={15} />
+              <UnlikedIcon width={12} height={11} />
             )}
-          </TouchableOpacity>
+          </Pressable>
         </View>
 
         {tags.length > 0 && (
@@ -96,58 +97,70 @@ const StoreListItem = ({
           </View>
         )}
 
-        <View style={[styles.infoRow, !showImages && { marginBottom: 0 }]}>
-          <View style={styles.infoItem}>
-            <StarIcon width={20} height={20} style={{ marginRight: 4 }} />
-            <Text style={styles.infoText}>{item.star}</Text>
-          </View>
+        <View style={styles.infoSection}>
+          <View style={styles.infoLeft}>
+            <View style={styles.infoItem}>
+              <StarIcon
+                width={20}
+                height={20}
+                style={styles.iconMargin}
+              />
+              <Text style={styles.infoText}>{item.star}</Text>
+            </View>
 
-          {showDiscountDetail ? (
-            item.partnerTitle && (
-              <View style={styles.infoItem}>
-                <TicketIcon width={20} height={20} style={{ marginRight: 4 }} />
-                <Text style={styles.infoText}>{item.partnerTitle}</Text>
-              </View>
-            )
-          ) : (
-            <>
-              {item.partnerTitle && (
+            {showDiscountDetail ? (
+              item.partnerTitle && (
                 <View style={styles.infoItem}>
                   <TicketIcon
                     width={20}
                     height={20}
-                    style={{ marginRight: 4 }}
+                    style={styles.iconMargin}
                   />
-                  <Text style={styles.infoText}>{item.partnerTitle}</Text>
+                  <Text style={styles.infoText}>
+                    {item.partnerTitle}
+                  </Text>
                 </View>
-              )}
-              <View style={styles.infoItem}>
-                <PinIcon width={20} height={20} style={{ marginRight: 4 }} />
-                <Text style={styles.infoText}>
-                  {item.address} {item.distance}
-                </Text>
-              </View>
-            </>
-          )}
-        </View>
-      </TouchableOpacity>
+              )
+            ) : (
+              <>
+                {item.partnerTitle && (
+                  <View style={styles.infoItem}>
+                    <TicketIcon
+                      width={20}
+                      height={20}
+                      style={styles.iconMargin}
+                    />
+                    <Text style={styles.infoText}>
+                      {item.partnerTitle}
+                    </Text>
+                  </View>
+                )}
+                <View style={styles.infoItem}>
+                  <PinIcon
+                    width={20}
+                    height={20}
+                    style={styles.iconMargin}
+                  />
+                  <Text style={styles.infoText}>{item.address}</Text>
+                  <Text style={styles.distanceText}>
+                    {' '}
+                    {item.distance}
+                  </Text>
+                </View>
+              </>
+            )}
+          </View>
 
-      {showImages && images.length > 0 && (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          style={styles.imageScroll}
-        >
-          {images.map((imgUrl, index) => (
+          {showImages && images.length > 0 && (
             <Image
-              key={index}
-              source={{ uri: imgUrl }}
-              style={styles.storeImage}
+              testID="store-thumbnail"
+              source={{ uri: images[0] }}
+              style={styles.thumbnail}
               resizeMode="cover"
             />
-          ))}
-        </ScrollView>
-      )}
+          )}
+        </View>
+      </Pressable>
     </View>
   );
 };
@@ -164,7 +177,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 8,
+    marginBottom: 4,
   },
   titleWrapper: {
     flexDirection: 'row',
@@ -172,12 +185,12 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   likeButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
     backgroundColor: theme.colors.background,
     borderWidth: 1,
-    borderColor: theme.colors.border,
+    borderColor: colors.gray[300],
     justifyContent: 'center',
     alignItems: 'center',
     marginLeft: 8,
@@ -191,12 +204,11 @@ const styles = StyleSheet.create({
     ...typography.caption1Regular,
     color: theme.colors.textDim,
   },
-
   tagRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginBottom: 10,
-    gap: 6,
+    marginBottom: 4,
+    gap: 4,
   },
   badge: {
     backgroundColor: theme.colors.primary1Light,
@@ -205,31 +217,38 @@ const styles = StyleSheet.create({
     borderRadius: 6,
   },
   badgeText: {
-    color: theme.colors.primary1,
+    color: colors.blue[600],
     ...typography.caption2Bold,
   },
-
-  infoRow: {
-    marginBottom: 8,
+  infoSection: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  infoLeft: {
+    flex: 1,
+    gap: 4,
   },
   infoItem: {
     flexDirection: 'row',
     alignItems: 'center',
     marginRight: 10,
   },
+  iconMargin: {
+    marginRight: 4,
+  },
   infoText: {
     ...typography.body4Regular,
     color: theme.colors.textDim,
   },
-  imageScroll: {
-    flexDirection: 'row',
+  distanceText: {
+    ...typography.caption1Regular,
+    color: colors.gray[400],
   },
-  storeImage: {
-    width: 88,
-    height: 88,
+  thumbnail: {
+    width: 68,
+    height: 68,
     borderRadius: 8,
     backgroundColor: theme.colors.backgroundSub,
-    marginRight: 8,
   },
 });
 

--- a/src/components/map/BottomSheet.js
+++ b/src/components/map/BottomSheet.js
@@ -13,7 +13,6 @@ import { useNavigation } from '@react-navigation/native';
 import StoreListItem from '../common/StoreListItem';
 import theme from '../../style';
 import colors from '../../style/colors';
-import { updatePlaceState } from '../../hooks/useMapLogic';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const HEIGHT_LIST = SCREEN_HEIGHT * 0.45;
@@ -107,9 +106,6 @@ const BottomSheet = ({
         renderItem={({ item }) => (
           <StoreListItem
             item={item}
-            onLikeToggle={(placeId, newData) => {
-              updatePlaceState(placeId, newData);
-            }}
             onPress={() => {
               onItemPress(item.placeId);
 
@@ -122,8 +118,8 @@ const BottomSheet = ({
                 },
               });
             }}
-            onLikeToggle={(oldId, newData) => {
-              if (onUpdateStore) onUpdateStore(oldId, newData);
+            onLikeToggle={(placeId, newData) => {
+              if (onUpdateStore) onUpdateStore(placeId, newData);
             }}
           />
         )}

--- a/src/utils/distance.js
+++ b/src/utils/distance.js
@@ -1,3 +1,15 @@
+/** 미터 단위 거리를 "X.Xkm"으로 */
+export const formatDistance = (meters) => {
+  if (!meters && meters !== 0) return '';
+  return `${(meters / 1000).toFixed(1)}km`;
+};
+
+/** 거리를 도보 시간(분)으로 변환 (평균 보행속도 67m/min 라고 하네요..) */
+export const calculateWalkingTime = (meters) => {
+  if (!meters && meters !== 0) return 0;
+  return Math.max(1, Math.round(meters / 67));
+};
+
 export const calculateDistance = (lat1, lon1, lat2, lon2) => {
   if (!lat1 || !lon1 || !lat2 || !lon2) return '';
 
@@ -8,9 +20,9 @@ export const calculateDistance = (lat1, lon1, lat2, lon2) => {
   const a =
     Math.sin(dLat / 2) * Math.sin(dLat / 2) +
     Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLon / 2) *
-      Math.sin(dLon / 2);
+    Math.cos((lat2 * Math.PI) / 180) *
+    Math.sin(dLon / 2) *
+    Math.sin(dLon / 2);
 
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   const distance = R * c;


### PR DESCRIPTION
## 📌 관련 이슈

close #78 

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

> 주요 변경 내용 요약

사진이 없는 경우를 가정해 지도뷰 매장 바텀시트 디자인 수정

## 🧩 세부 내용

- [x] 지도뷰 매장 바텀시트 디자인 수정

## 📸 스크린샷 (선택)
<img width="573" height="1272" alt="image" src="https://github.com/user-attachments/assets/475e4217-9214-46a5-bff6-f31bfc969441" />

## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

- API와 기존 코드 `console.log` 부분도 같이 수정 했습니다!
- `transform` 부분은 홀수라.. 최대한 중간이 맞아 보이게 하면서 넣었습니다!

<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
