### PR TITLE
[Feature] Play Store 출시용 Keystore 생성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           KAKAO_NATIVE_APP_KEY=ci_dummy_key
           EOF
 
+      - name: Create gradle.properties from example
+        run: cp android/gradle.properties.example android/gradle.properties
+
       - name: Build Android Debug
         working-directory: android
         run: ./gradlew assembleDebug -Dorg.gradle.java.home=$JAVA_HOME --no-daemon -PreactNativeArchitectures=x86_64

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ yarn-error.log
 !.yarn/versions
 
 .env
+
+안드로이드 서명
+android/app/our-campus-release.jks

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ yarn-error.log
 
 안드로이드 서명
 android/app/our-campus-release.jks
+android/gradle.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.ourcampusapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
+        versionCode 2
         versionName "1.0"
 
         def kakaoKey = localProperties['KAKAO_NATIVE_APP_KEY'] ?: ""

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -106,15 +106,26 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        release {
+            def storeFileName = project.findProperty('OURCAMPUS_UPLOAD_STORE_FILE') ?: System.getenv('OURCAMPUS_UPLOAD_STORE_FILE')
+            def storePass = project.findProperty('OURCAMPUS_UPLOAD_STORE_PASSWORD') ?: System.getenv('OURCAMPUS_UPLOAD_STORE_PASSWORD')
+            def keyAliasName = project.findProperty('OURCAMPUS_UPLOAD_KEY_ALIAS') ?: System.getenv('OURCAMPUS_UPLOAD_KEY_ALIAS')
+            def keyPass = project.findProperty('OURCAMPUS_UPLOAD_KEY_PASSWORD') ?: System.getenv('OURCAMPUS_UPLOAD_KEY_PASSWORD')
+
+            if (storeFileName) {
+                storeFile file(storeFileName)
+                storePassword storePass
+                keyAlias keyAliasName
+                keyPassword keyPass
+            }
+        }
     }
     buildTypes {
         debug {
             signingConfig = signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig = signingConfigs.debug
+            signingConfig = signingConfigs.release
             minifyEnabled = enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/android/gradle.properties.example
+++ b/android/gradle.properties.example
@@ -48,3 +48,9 @@ org.gradle.caching=true
 
 # Project-level JDK 17 (글로벌 설정 의존 제거)
 org.gradle.java.home=C:/Program Files/Java/jdk-17
+
+# Android 서명
+OURCAMPUS_UPLOAD_STORE_FILE=our-campus-release.jks
+OURCAMPUS_UPLOAD_KEY_ALIAS=ourcampus
+OURCAMPUS_UPLOAD_STORE_PASSWORD=
+OURCAMPUS_UPLOAD_KEY_PASSWORD=

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format:check": "prettier --check \"src/**/*.js\" \"*.{js,json,md}\"",
     "start": "react-native start",
     "test": "jest",
-    "android:release": "cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a",
+    "version:bump:android": "node scripts/bump-android-version-code.js",
+    "android:release": "node scripts/android-release.js",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/android-release.js
+++ b/scripts/android-release.js
@@ -1,0 +1,21 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const { bumpAndroidVersionCode } = require('./bump-android-version-code');
+
+// armeabi-v7a는 Windows MAX_PATH(260자) 제한으로 CMake 빌드 실패. 추후 필요하면 다시 추가
+const ABIS = 'arm64-v8a,x86,x86_64';
+const androidDir = path.join(__dirname, '..', 'android');
+const gradlew = path.join(
+  androidDir,
+  process.platform === 'win32' ? 'gradlew.bat' : 'gradlew'
+);
+
+bumpAndroidVersionCode();
+
+const result = spawnSync(
+  gradlew,
+  ['bundleRelease', `-PreactNativeArchitectures=${ABIS}`],
+  { cwd: androidDir, stdio: 'inherit', shell: process.platform === 'win32' }
+);
+
+process.exit(result.status ?? 1);

--- a/scripts/bump-android-version-code.js
+++ b/scripts/bump-android-version-code.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function bumpAndroidVersionCode() {
+  const gradlePath = path.join(
+    __dirname,
+    '..',
+    'android',
+    'app',
+    'build.gradle'
+  );
+  const content = fs.readFileSync(gradlePath, 'utf8');
+
+  const match = content.match(/versionCode\s+(\d+)/);
+  if (!match) {
+    throw new Error('[bump] versionCode not found in android/app/build.gradle');
+  }
+
+  const current = parseInt(match[1], 10);
+  const next = current + 1;
+  const updated = content.replace(/versionCode\s+\d+/, `versionCode ${next}`);
+  fs.writeFileSync(gradlePath, updated);
+
+  console.log(`[bump] android versionCode: ${current} → ${next}`);
+  return { current, next };
+}
+
+if (require.main === module) {
+  try {
+    bumpAndroidVersionCode();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { bumpAndroidVersionCode };


### PR DESCRIPTION
## 📌 관련 이슈

close #124 

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

> 주요 변경 내용 요약

앞으로의 Play Store출시와 관리를 위한 Ksystore 생성 및 빌드 스크립트 추

## 🧩 세부 내용

- [x] Keystore 생성
- [x] gitignore에 keystore추가
- [x] gradle.properties에 서명용 비번 추가
- [x] build.gradle의 debug키를 교체
- [x] 빌드 스크립트 추가

## 📸 스크린샷 (선택)

## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

추후 ProGuard 설정 고려 필요, 라이브러리 호환성 검토 선행이 필수
