### PR TITLE
[Hotfix] release에서 백엔트 통신 오류

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.ourcampusapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
+        versionCode 3
         versionName "1.0"
 
         def kakaoKey = localProperties['KAKAO_NATIVE_APP_KEY'] ?: ""

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="false"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="${usesCleartextTraffic}"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true">
 
         <meta-data

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">158.179.193.224</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## 📌 관련 이슈

close #126 

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

> 주요 변경 내용 요약

Backend가 http endpoint이기에 Android에서 차단하여 임시로 backend 호스트만 cleartext 허용

## 🧩 세부 내용

- [x] 임시로 backend 서버만 cleartext 허용

## 📸 스크린샷 (선택)

## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
