### PR TITLE
[Fix] 리뷰 작성 시 temp placeId가 전달되던 문제 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,8 +95,9 @@ android {
 
         def kakaoKey = localProperties['KAKAO_NATIVE_APP_KEY'] ?: ""
         manifestPlaceholders = [
-            KAKAO_NATIVE_APP_KEY: kakaoKey,
-            KAKAO_APP_SCHEME    : "kakao${kakaoKey}"
+            KAKAO_NATIVE_APP_KEY    : kakaoKey,
+            KAKAO_APP_SCHEME        : "kakao${kakaoKey}",
+            usesCleartextTraffic    : false
         ]
     }
     signingConfigs {

--- a/src/screens/Store/StoreDetailScreen.js
+++ b/src/screens/Store/StoreDetailScreen.js
@@ -498,7 +498,7 @@ const StoreDetailScreen = () => {
               // }
               navigation.navigate('WriteReviewScreen', {
                 store: storeData,
-                placeId: storeData.placeId,
+                placeId: storeData.backendPlaceId || null,
                 placeKey: storeData.placeKey,
                 storeName: storeData.name,
                 rating: storeData.star,

--- a/src/screens/Store/WriteReviewScreen.js
+++ b/src/screens/Store/WriteReviewScreen.js
@@ -134,8 +134,7 @@ const WriteReviewScreen = () => {
         const uploadedUrls =
           newPhotos.length > 0 ? await uploadPhotos(newPhotos) : [];
         const allImageUrls = [...existingUrls, ...uploadedUrls];
-
-        await editReview(existingReview.reviewId || existingReview.id, {
+        const editPayload = {
           content: reviewText,
           star: rating,
           imageUrls: allImageUrls,
@@ -145,7 +144,9 @@ const WriteReviewScreen = () => {
             placeKey: existingReview.placeKey,
             coordinate: existingReview.coordinate,
           },
-        });
+        };
+
+        await editReview(existingReview.reviewId || existingReview.id, editPayload);
         showToast('리뷰가 수정되었습니다.');
         navigation.goBack();
       } catch (error) {
@@ -158,27 +159,28 @@ const WriteReviewScreen = () => {
 
     try {
       const store = route.params?.store;
-      const placeId = route.params?.placeId;
+      const rawPlaceId = route.params?.placeId;
+      const placeId = rawPlaceId && !String(rawPlaceId).startsWith('temp_') ? rawPlaceId : null;
       const isPartnership = store?.isPartnership || store?.isPartner;
-
       const imageUrls = await uploadPhotos();
 
       let result;
       if (isPartnership && placeId) {
-        result = await createPartnershipReview(placeId, {
+        const partnerPayload = {
           content: reviewText,
           star: rating,
           isVerified: false,
           imageUrls,
-        });
+        };
+        result = await createPartnershipReview(placeId, partnerPayload);
       } else {
-        result = await createReview({
+        const reviewPayload = {
           content: reviewText,
           star: rating,
           imageUrls,
           place: store
             ? {
-                placeId: store.placeId || null,
+                placeId: store.backendPlaceId || null,
                 placeName: store.name || store.placeName || '',
                 placeKey: store.placeKey || '',
                 address: store.address || '',
@@ -202,7 +204,8 @@ const WriteReviewScreen = () => {
                 coordinate: { latitude: 0, longitude: 0 },
                 imgUrls: [],
               },
-        });
+        };
+        result = await createReview(reviewPayload);
       }
 
       const reviewCaseType = isPartnership && placeId ? 3 : 4;


### PR DESCRIPTION


## 📌 관련 이슈

close #138

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

> 주요 변경 내용 요약

<!-- 어떤 기능을 추가/수정했는지 간단히 설명 -->

미제휴 매장의 경우 리뷰 작성 시 placeId가 임시 값인 temp_* 값으로 전달되어 리뷰 작성이 실패하는 에러 수정

## 🧩 세부 내용

-  [x] StoreDetailScreen에서 WriteReviewScreen으로 backendPlaceId 전달
- [x] WriteReviewScreen에서 temp_ 접두사 placeId를 null 처리하는 방어 코드 추가
- [x] createReview payload의 place.placeId도 backendPlaceId 사용으로 수정
- [x] manifestPlaceholders에 usesCleartextTraffic 명시 (HTTPS 전환으로 false)

## 📸 스크린샷 (선택)

## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
