### PR TITLE
[Fix] 라우팅 처리 및 리뷰 관련 수정

### DIFF
--- a/src/components/Affiliation/HostByTab.js
+++ b/src/components/Affiliation/HostByTab.js
@@ -40,15 +40,16 @@ const styles = StyleSheet.create({
 
 const HostByTab = ({
   navigation,
-  // school,
-  // college,
-  // major,
   isOrange = false,
   onSelectTab = null,
   selectedTab = 'school',
 }) => {
   const [activeTab, setActiveTab] = useState(selectedTab);
   const user = useAuthStore((state) => state.user);
+
+  useEffect(() => {
+    setActiveTab(selectedTab);
+  }, [selectedTab]);
   return (
     <View style={styles.container}>
       <Pressable

--- a/src/components/Affiliation/RecommendStoreCard.js
+++ b/src/components/Affiliation/RecommendStoreCard.js
@@ -11,14 +11,26 @@ import theme from '@style';
 
 const RecommendStoreCard = ({ item, variant = 'short', rank }) => {
   const isLong = variant === 'long';
-  const isEvent = item?.type === '행사';
-  const isPartner = item?.type === '제휴';
+  const isEvent = item?.type === '행사' || item?.activityType === '행사';
+  const isPartner = item?.type === '제휴' || item?.activityType === '제휴';
   const iconSize = isLong ? 20 : 15;
 
-  const name = item?.placeName ?? item?.place ?? item?.name;
+  // 1. 카드 메인 제목 (title 최우선)
+  const name = item?.title || item?.name || item?.placeName;
   const category = item?.placeType ?? item?.category;
-  const benefit = item?.detail ?? item?.benefit ?? item?.title;
-  const distance = item?.distance;
+
+  // 2. 📍 공통: 장소 정보 (제휴, 행사 둘 다 사용)
+  const place = item?.placeName || item?.place;
+
+  // 3. 🎫 제휴 전용 데이터 (혜택 상세)
+  const benefit = item?.detail ?? item?.benefit;
+
+  // 4. 📅 행사 전용 데이터 (날짜)
+  let eventDate = item?.date;
+  if (!eventDate && (item?.endDateTime || item?.startDateTime)) {
+    const targetDate = item?.endDateTime || item?.startDateTime;
+    eventDate = targetDate.split('T')[0].replace(/-/g, '.');
+  }
 
   const detailTextStyle = isLong
     ? styles.detailTextLong
@@ -50,37 +62,46 @@ const RecommendStoreCard = ({ item, variant = 'short', rank }) => {
             {category}
           </Text>
         </View>
+
         <View style={styles.detailWrapper}>
-          {isPartner && benefit && (
-            <View style={styles.detailRow}>
-              <CouponIcon width={iconSize} height={iconSize} />
-              <Text
-                numberOfLines={2}
-                ellipsizeMode="tail"
-                textBreakStrategy="balanced"
-                style={[detailTextStyle, styles.detailRowText]}
-              >
-                {benefit}
-              </Text>
-            </View>
-          )}
-          {isEvent && item?.date && (
-            <View style={styles.detailRow}>
-              <CalendarIcon width={iconSize} height={iconSize} />
-              <Text style={[detailTextStyle, styles.detailRowText]}>
-                {item.date}
-              </Text>
-            </View>
-          )}
-          {distance && (
+          {/* ✅ 1. 공통: 장소 정보 (제휴든 행사든 무조건 띄움) */}
+          {place && (
             <View style={styles.detailRow}>
               <PlaceIcon
                 width={iconSize}
                 height={iconSize}
                 color={colors.gray[300]}
               />
+              <Text
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                style={[detailTextStyle, styles.detailRowText]}
+              >
+                {place}
+              </Text>
+            </View>
+          )}
+
+          {/* ✅ 2. 제휴일 경우: 쿠폰 아이콘 (상세 혜택 내용) */}
+          {isPartner && benefit && (
+            <View style={styles.detailRow}>
+              <CouponIcon width={iconSize} height={iconSize} />
+              <Text
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                style={[detailTextStyle, styles.detailRowText]}
+              >
+                {benefit}
+              </Text>
+            </View>
+          )}
+
+          {/* ✅ 3. 행사일 경우: 달력 아이콘 (날짜) */}
+          {isEvent && eventDate && (
+            <View style={styles.detailRow}>
+              <CalendarIcon width={iconSize} height={iconSize} />
               <Text style={[detailTextStyle, styles.detailRowText]}>
-                {distance}
+                {eventDate}
               </Text>
             </View>
           )}

--- a/src/components/home/AffiliateSection.js
+++ b/src/components/home/AffiliateSection.js
@@ -101,7 +101,6 @@ const AffiliateSection = () => {
             onPress={() => {
               navigation.navigate('AffiliationDetailScreen', {
                 councilType: selectedTabId.toLowerCase(),
-
                 item: {
                   ...item,
                   id: item.postId,
@@ -135,7 +134,12 @@ const AffiliateSection = () => {
 
       <TouchableOpacity
         style={styles.moreButton}
-        onPress={() => navigation.navigate('Partnership')}
+        onPress={() =>
+          navigation.navigate('Partnership', {
+            screen: 'AffiliationMainScreen',
+            params: { initialTab: selectedTabId.toLowerCase() },
+          })
+        }
       >
         <Text style={styles.moreText}>이용 가능한 제휴 더보기</Text>
       </TouchableOpacity>

--- a/src/screens/Affiliation/AffiliationDetailScreen.js
+++ b/src/screens/Affiliation/AffiliationDetailScreen.js
@@ -326,7 +326,7 @@ const AffiliationDetailScreen = ({ navigation, route }) => {
             </View>
           </View>
         )}
-        {!isEmpty && !isFirstImageLoaded ? null : (
+        {!isEmpty && !isFirstImageLoaded ? null : recommendData.length > 0 ? (
           <View style={styles.recommendContainer}>
             {detailData?.category === 'PARTNERSHIP' ? (
               <Text style={styles.recommendTitle}>
@@ -347,12 +347,16 @@ const AffiliationDetailScreen = ({ navigation, route }) => {
               renderItem={({ item }) => (
                 <Pressable
                   onPress={() => {
-                    navigation.push('AffiliationDetailScreen', {
-                      councilType,
-                      item: {
+                    navigation.push('StoreDetailScreen', {
+                      store: {
                         ...item,
-                        id: item.postId || item.id,
-                        placeName: item.place || item.placeName,
+                        name: item.placeName || item.place || item.name,
+                        imgUrls: item.imgUrls || (item.thumbnailImageUrl ? [item.thumbnailImageUrl] : []),
+                        isPartnership: item.type === '제휴',
+                        partnerships:
+                          item.type === '제휴' && detailData?.writerName
+                            ? [{ councilName: detailData.writerName }]
+                            : [],
                       },
                     });
                   }}
@@ -360,10 +364,10 @@ const AffiliationDetailScreen = ({ navigation, route }) => {
                   <RecommendStoreCard item={item} />
                 </Pressable>
               )}
-              keyExtractor={(item) => item.id}
+              keyExtractor={(item) => String(item.id || item.postId)}
             />
           </View>
-        )}
+        ) : null}
       </ScrollView>
       <Toast message={toastMessage} visible={toastVisible} onHide={hideToast} />
     </SafeAreaView>

--- a/src/screens/Affiliation/AffiliationDetailScreen.js
+++ b/src/screens/Affiliation/AffiliationDetailScreen.js
@@ -330,8 +330,7 @@ const AffiliationDetailScreen = ({ navigation, route }) => {
           <View style={styles.recommendContainer}>
             {detailData?.category === 'PARTNERSHIP' ? (
               <Text style={styles.recommendTitle}>
-                {detailData?.writerName}에서 진행하는 {'\n'}다른 제휴 매장
-                둘러보기
+                {detailData?.writerName}에서 진행하는 다른 제휴 매장 둘러보기
               </Text>
             ) : (
               <Text style={styles.recommendTitle}>
@@ -340,28 +339,38 @@ const AffiliationDetailScreen = ({ navigation, route }) => {
             )}
             <FlatList
               data={recommendData}
-              horizontal
-              contentContainerStyle={{ gap: 10 }}
-              style={{ marginTop: 20 }}
+              horizontal={true} // 무조건 가로 스크롤
               showsHorizontalScrollIndicator={false}
+              style={{ marginTop: 20 }}
+              contentContainerStyle={{ gap: 10 }}
               renderItem={({ item }) => (
                 <Pressable
                   onPress={() => {
-                    navigation.push('StoreDetailScreen', {
-                      store: {
-                        ...item,
-                        name: item.placeName || item.place || item.name,
-                        imgUrls: item.imgUrls || (item.thumbnailImageUrl ? [item.thumbnailImageUrl] : []),
-                        isPartnership: item.type === '제휴',
-                        partnerships:
-                          item.type === '제휴' && detailData?.writerName
-                            ? [{ councilName: detailData.writerName }]
+                    if (detailData?.category === 'PARTNERSHIP') {
+                      navigation.push('StoreDetailScreen', {
+                        store: {
+                          ...item,
+                          name: item.placeName || item.place || item.name,
+                          imgUrls: item.thumbnailImageUrl
+                            ? [item.thumbnailImageUrl]
                             : [],
-                      },
-                    });
+                          isPartnership: true,
+                          tag: detailData?.writerName,
+                        },
+                      });
+                    } else {
+                      navigation.push('AffiliationDetailScreen', {
+                        item: {
+                          ...item,
+                          id: item.postId || item.id,
+                          placeName: item.place || item.placeName,
+                        },
+                        councilType,
+                      });
+                    }
                   }}
                 >
-                  <RecommendStoreCard item={item} />
+                  <RecommendStoreCard item={item} variant="short" />
                 </Pressable>
               )}
               keyExtractor={(item) => String(item.id || item.postId)}

--- a/src/screens/Affiliation/AffiliationMainScreen.js
+++ b/src/screens/Affiliation/AffiliationMainScreen.js
@@ -13,9 +13,8 @@ import EmptyResult from '../../components/common/EmptyResult';
 import useToast from '../../hooks/useToast';
 import colors from '../../style/colors';
 import typography from '../../style/typography';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
-import { useCallback } from 'react';
 import HostByTab from '../../components/Affiliation/HostByTab';
 import AffiliationCarousel from '../../components/Affiliation/AffiliationCarousel';
 import AffiliationColumnListItem from '../../components/Affiliation/AffiliationColumnListItem';
@@ -127,12 +126,19 @@ const UPCOMING_FETCH_MAP = {
   college: getStudentCollegeUpcomingEventList,
 };
 
-const AffiliationMainScreen = ({ navigation }) => {
+const AffiliationMainScreen = ({ navigation, route }) => {
   const [selectedActivityType, setSelectedActivityType] = useState('제휴');
   const [isSearchMode, setIsSearchMode] = useState(false);
   const [searchText, setSearchText] = useState('');
   const { accessToken } = useAuthStore();
-  const [selectedTab, setSelectedTab] = useState('school');
+  const [selectedTab, setSelectedTab] = useState(route?.params?.initialTab || 'school');
+
+  useEffect(() => {
+    const initialTab = route?.params?.initialTab;
+    if (initialTab && initialTab !== selectedTab) {
+      setSelectedTab(initialTab);
+    }
+  }, [route?.params?.initialTab]);
   const { toastVisible, toastMessage, showToast, hideToast } = useToast();
 
   // 제휴 페이지네이션
@@ -297,10 +303,8 @@ const AffiliationMainScreen = ({ navigation }) => {
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <View style={{ marginTop: 9.5 }}>
         <HostByTab
-          // school={'중앙대학교'}
-          // college={'사회과학대'}
-          // major={'정치국제'}
           onSelectTab={handleSelectTab}
+          selectedTab={selectedTab}
         />
       </View>
       {upcomingEvents.length > 0 && (

--- a/src/screens/MyPage/InterestedAffiliateScreen.js
+++ b/src/screens/MyPage/InterestedAffiliateScreen.js
@@ -3,6 +3,7 @@ import LabelTitle from '../../components/LabelTitle';
 import colors from '../../style/colors';
 import typography from '../../style/typography';
 import AffiliationColumnListItem from '../../components/Affiliation/AffiliationColumnListItem';
+import EmptyResult from '../../components/common/EmptyResult';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useState, useEffect } from 'react';
 import { FlatList } from 'react-native';
@@ -115,7 +116,10 @@ const InterestedAffiliateScreen = ({ navigation }) => {
               alwaysShowLiked={true}
             />
           )}
-          keyExtractor={(item) => item?.id || item?.postId}
+          keyExtractor={(item) => String(item?.id || item?.postId)}
+          ListEmptyComponent={
+            <EmptyResult message="관심 게시글이 없습니다." paddingTop={100} />
+          }
         />
       )}
       {selectedActivityType === '행사' && (
@@ -132,7 +136,10 @@ const InterestedAffiliateScreen = ({ navigation }) => {
               alwaysShowLiked={true}
             />
           )}
-          keyExtractor={(item) => item?.id || item?.postId}
+          keyExtractor={(item) => String(item?.id || item?.postId)}
+          ListEmptyComponent={
+            <EmptyResult message="관심 게시글이 없습니다." paddingTop={100} />
+          }
         />
       )}
     </SafeAreaView>

--- a/src/screens/Store/StoreDetailScreen.js
+++ b/src/screens/Store/StoreDetailScreen.js
@@ -88,6 +88,7 @@ const StoreDetailScreen = () => {
     isPartner:
       paramStore.isPartnership ||
       paramStore.type === 'PARTNER' ||
+      paramStore.category === 'PARTNER' ||
       paramStore.partnerships?.length > 0,
     partnerTags:
       paramStore.partnerships?.length > 0
@@ -195,7 +196,7 @@ const StoreDetailScreen = () => {
             const fetchedIsPartner =
               status.isPartnership || status.partnerships?.length > 0;
             if (fetchedIsPartner !== undefined) {
-              setIsPartner(!!fetchedIsPartner);
+              setIsPartner((prev) => prev || !!fetchedIsPartner);
             }
             if (status.partnerships?.length > 0) {
               setPartnerTags(

--- a/src/screens/Store/StoreDetailScreen.js
+++ b/src/screens/Store/StoreDetailScreen.js
@@ -115,6 +115,8 @@ const StoreDetailScreen = () => {
   );
   const [reviews, setReviews] = useState(storeData.reviews);
   const [reviewSize, setReviewSize] = useState(storeData.reviewSize);
+  const [isPartner, setIsPartner] = useState(storeData.isPartner);
+  const [partnerTags, setPartnerTags] = useState(storeData.partnerTags);
 
   useEffect(() => {
     if (!storeData.backendPlaceId || storeData.reviews?.length > 0) return;
@@ -189,6 +191,16 @@ const StoreDetailScreen = () => {
             setIsLiked(status.isLiked);
             if (status.placeId && !currentPlaceId) {
               setCurrentPlaceId(status.placeId);
+            }
+            const fetchedIsPartner =
+              status.isPartnership || status.partnerships?.length > 0;
+            if (fetchedIsPartner !== undefined) {
+              setIsPartner(!!fetchedIsPartner);
+            }
+            if (status.partnerships?.length > 0) {
+              setPartnerTags(
+                status.partnerships.map((p) => p.councilName).filter(Boolean)
+              );
             }
           }
         } catch (error) {
@@ -330,9 +342,9 @@ const StoreDetailScreen = () => {
               </View>
             </View>
 
-            {storeData.isPartner ? (
+            {isPartner ? (
               <View style={styles.partnerTagRow}>
-                {storeData.partnerTags?.map((tag, index) => (
+                {partnerTags?.map((tag, index) => (
                   <TouchableOpacity key={index} style={styles.partnerTag}>
                     <Text style={styles.partnerTagText}>{tag}</Text>
                     <ArrowRightIcon


### PR DESCRIPTION
## 📌 관련 이슈

close #137

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

> 주요 변경 내용 요약

<!-- 어떤 기능을 추가/수정했는지 간단히 설명 -->
홈 화면 페이지 이동 처리, 마이페이지 empty state 처리, 제휴보기 하단 추천 배너 관련 수정

## 🧩 세부 내용

- [x] 카테고리 항목 선택 시 제휴 상세로 진입 (기획 논의 후 매장 상세 -> 제휴 상세로 변경)
- [x] 카테고리 내 선택된 학생회 제휴보기 탭 진입
- [x] 다가오는 행사가 없는 경우 하단 섹션이 노출되지 않아야하는데 제목만 노출
- [x] 제휴보기 -> 추천 배너 내용에 ‘제목, 장소, 날짜’가 표시되어야하는데 제목만 표시됨
- [x] 마이페이지 -> 관심게시물 없는 경우 처리

## 📸 스크린샷 (선택)
<img width="356" height="667" alt="image" src="https://github.com/user-attachments/assets/11c482c7-91a2-4f0c-acde-d87cb8620dd7" />


## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
제휴 보기 > 제휴 매장의 경우 매장 상세가 아닌 제휴 상세로 이동 (행사와 동일한 동작)
추후 백엔드에 해당 부분 API 추가 요청... 고민...