### PR TITLE
[Fix] 학생회 제휴 글쓰기 관련 버그 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,8 +90,8 @@ android {
         applicationId "com.ourcampusapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 5
-        versionName "1.0"
+        versionCode 6
+        versionName "1.1"
 
         def kakaoKey = localProperties['KAKAO_NATIVE_APP_KEY'] ?: ""
         manifestPlaceholders = [

--- a/src/components/Affiliation/AffiliationColumnListItem.js
+++ b/src/components/Affiliation/AffiliationColumnListItem.js
@@ -160,13 +160,6 @@ const AffiliationColumnListItem = ({
         onPress={handleItemPress}
         disabled={shouldShowSkeleton}
       >
-        <View style={styles.threeDotIconContainer}>
-          {isCouncil && (
-            <Pressable onPress={() => handleThreeDotIconPress?.(item)}>
-              <ThreeDotIcon width={20} height={20} color={colors.gray[300]} />
-            </Pressable>
-          )}
-        </View>
         {item?.thumbnailImageUrl ? (
           <View style={styles.imageContainer}>
             <Image
@@ -236,6 +229,13 @@ const AffiliationColumnListItem = ({
           </View>
         </View>
       </Pressable>
+      {isCouncil && (
+        <View style={[styles.threeDotIconContainer, { zIndex: 2 }]}>
+          <Pressable onPress={() => handleThreeDotIconPress?.(item)}>
+            <ThreeDotIcon width={20} height={20} color={colors.gray[300]} />
+          </Pressable>
+        </View>
+      )}
     </View>
   );
 };

--- a/src/screens/Council/AffiliateCreate/AffiliateEditScreen.js
+++ b/src/screens/Council/AffiliateCreate/AffiliateEditScreen.js
@@ -151,7 +151,7 @@ const AffiliateEditScreen = ({ navigation, route }) => {
                 quality: 0.8,
                 maxWidth: 1000,
                 maxHeight: 1000,
-                selectionLimit: 0, // ⭐ 여러 장 선택 (0 = 무제한)
+                selectionLimit: 10,
               },
               (response) => {
                 if (response.didCancel) return;

--- a/src/screens/Council/AffiliateCreate/EventEditScreen.js
+++ b/src/screens/Council/AffiliateCreate/EventEditScreen.js
@@ -164,7 +164,7 @@ const EventEditScreen = ({ navigation, route }) => {
                 quality: 0.8,
                 maxWidth: 1000,
                 maxHeight: 1000,
-                selectionLimit: 0, // ⭐ 여러 장 선택 (0 = 무제한)
+                selectionLimit: 10,
               },
               (response) => {
                 if (response.didCancel) return;

--- a/src/screens/Council/AffiliateCreate/EventEditScreen.js
+++ b/src/screens/Council/AffiliateCreate/EventEditScreen.js
@@ -38,7 +38,7 @@ import {
   getCouncilImagePresignedUrl,
   uploadImageToPresignedUrl,
 } from '../../../api/uploadImage';
-import Toast from 'react-native-toast-message';
+import Toast from '../../../components/common/Toast';
 
 const EventEditScreen = ({ navigation, route }) => {
   const [placeInfo, setPlaceInfo] = useState(null);
@@ -119,6 +119,7 @@ const EventEditScreen = ({ navigation, route }) => {
   const scrollViewRef = useRef(null);
 
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [toastVisible, setToastVisible] = useState(false);
 
   const onViewableItemsChanged = useRef(({ viewableItems }) => {
     if (viewableItems.length > 0) {
@@ -284,21 +285,7 @@ const EventEditScreen = ({ navigation, route }) => {
     );
     console.log('response at handleSubmitEvent', response);
     if (response.data.code === 200) {
-      Toast.show({
-        type: 'success',
-        text1: '행사 글 수정 성공',
-        text2: '행사 글이 성공적으로 수정되었습니다.',
-        position: 'top',
-        topOffset: 100,
-        visibilityTime: 1000,
-        autoHide: true,
-      });
-      setTimeout(() => {
-        navigation?.reset({
-          index: 0,
-          routes: [{ name: 'CouncilAffiliateScreen' }],
-        });
-      }, 1000);
+      setToastVisible(true);
     } else {
       Alert.alert('행사 글 수정에 실패했습니다.', response.data.message);
     }
@@ -456,7 +443,19 @@ const EventEditScreen = ({ navigation, route }) => {
           />
         </View>
       </ScrollView>
-      <Toast />
+      <Toast
+        message="행사 글이 성공적으로 수정되었습니다."
+        visible={toastVisible}
+        duration={1000}
+        hasNavBar={false}
+        onHide={() => {
+          setToastVisible(false);
+          navigation?.reset({
+            index: 0,
+            routes: [{ name: 'CouncilAffiliateScreen' }],
+          });
+        }}
+      />
       {showStartPicker && Platform.OS === 'ios' && (
         <View style={styles.datePickerContainer}>
           <DateTimePicker

--- a/src/screens/Council/AffiliateCreate/WriteAffiliatePostScreen.js
+++ b/src/screens/Council/AffiliateCreate/WriteAffiliatePostScreen.js
@@ -91,7 +91,7 @@ const WriteAffiliatePostScreen = ({ navigation, route }) => {
                 quality: 0.8,
                 maxWidth: 1000,
                 maxHeight: 1000,
-                selectionLimit: 0, // ⭐ 여러 장 선택 (0 = 무제한)
+                selectionLimit: 10,
               },
               (response) => {
                 if (response.didCancel) return;

--- a/src/screens/Council/AffiliateCreate/WriteEventPostScreen.js
+++ b/src/screens/Council/AffiliateCreate/WriteEventPostScreen.js
@@ -104,7 +104,7 @@ const WriteEventPostScreen = ({ navigation, route }) => {
                 quality: 0.8,
                 maxWidth: 1000,
                 maxHeight: 1000,
-                selectionLimit: 0, // ⭐ 여러 장 선택 (0 = 무제한)
+                selectionLimit: 10,
               },
               (response) => {
                 if (response.didCancel) return;

--- a/src/screens/Council/CouncilAffiliateDetailScreen.js
+++ b/src/screens/Council/CouncilAffiliateDetailScreen.js
@@ -52,9 +52,15 @@ const CouncilAffiliateDetailScreen = ({ navigation, route }) => {
   const handleEdit = () => {
     setIsMenuVisible(false);
     if (category === 'PARTNERSHIP') {
-      navigation.navigate('AffiliateEditScreen', { postId });
+      navigation.navigate('AffiliateEditScreen', {
+        type: 'affiliate',
+        item: route.params?.item,
+      });
     } else {
-      navigation.navigate('EventEditScreen', { postId });
+      navigation.navigate('EventEditScreen', {
+        type: 'event',
+        item: route.params?.item,
+      });
     }
   };
 


### PR DESCRIPTION
## 📌 관련 이슈

close #145

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

> 주요 변경 내용 요약

<!-- 어떤 기능을 추가/수정했는지 간단히 설명 -->
학생회 제휴/행사 글쓰기 관련 버그 수정

## 🧩 세부 내용

- 수정 화면 진입 시 기존 데이터 미표시 문제 수정
  - CouncilAffiliateDetailScreen에서 수정 화면으로 이동 시 postId만 전달하던 것을 item 전체를 전달하도록 수정
  - 제휴/행사 수정 화면에서 기존 데이터가 정상적으로 채워지지 않던 문제 해결
- 행사 수정 완료 토스트 교체
  - react-native-toast-message → 프로젝트 공통 Toast 컴포넌트로 교체
- 이미지 선택 최대 10장 제한

## 📸 스크린샷 (선택)

## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
