### PR TITLE
[Fix]: 학생회 화면 2차 QA

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.ourcampusapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
+        versionCode 10
         versionName "1.0"
 
         def kakaoKey = localProperties['KAKAO_NATIVE_APP_KEY'] ?: ""

--- a/src/components/MyPage/AnnouncementTypeSelector.js
+++ b/src/components/MyPage/AnnouncementTypeSelector.js
@@ -34,19 +34,6 @@ const AnnouncementTypeSelector = ({ navigation }) => {
           {'이벤트 안내'}
         </Text>
       </Pressable>
-      <Pressable
-        style={[styles.button, activeTab === 'event2' && styles.activeButton]}
-        onPress={() => setActiveTab('event2')}
-      >
-        <Text
-          style={[
-            styles.buttonText,
-            activeTab === 'event2' && styles.activeButtonText,
-          ]}
-        >
-          {'이벤트 안내'}
-        </Text>
-      </Pressable>
     </View>
   );
 };

--- a/src/components/common/ConfirmModal.js
+++ b/src/components/common/ConfirmModal.js
@@ -10,6 +10,7 @@ const ConfirmModal = ({
   description,
   confirmText = '확인',
   cancelText = '취소',
+  confirmButtonColor = colors.orange[400],
 }) => {
   return (
     <Modal
@@ -24,7 +25,7 @@ const ConfirmModal = ({
           {description ? (
             <Text style={styles.description}>{description}</Text>
           ) : null}
-          <Pressable style={styles.confirmButton} onPress={onConfirm}>
+          <Pressable style={[styles.confirmButton, { backgroundColor: confirmButtonColor }]} onPress={onConfirm}>
             <Text style={styles.confirmText}>{confirmText}</Text>
           </Pressable>
           <Pressable style={styles.cancelButton} onPress={onClose}>
@@ -68,7 +69,6 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingVertical: 14,
     borderRadius: 12,
-    backgroundColor: colors.blue[400],
     alignItems: 'center',
     marginBottom: 12,
   },

--- a/src/screens/Council/AffiliateCreate/WriteAffiliatePostScreen.js
+++ b/src/screens/Council/AffiliateCreate/WriteAffiliatePostScreen.js
@@ -121,12 +121,12 @@ const WriteAffiliatePostScreen = ({ navigation, route }) => {
   };
 
   useEffect(() => {
-    if (title && place && startDate && endDate) {
+    if (title && place && startDate && endDate && selectedImages.length > 0) {
       setIsButtonDisabled(false);
     } else {
       setIsButtonDisabled(true);
     }
-  }, [title, place, startDate, endDate]);
+  }, [title, place, startDate, endDate, selectedImages]);
 
   const handleSubmit = () => {
     if (eventType === 'affiliate') {

--- a/src/screens/Council/AffiliateCreate/WriteEventPostScreen.js
+++ b/src/screens/Council/AffiliateCreate/WriteEventPostScreen.js
@@ -176,12 +176,12 @@ const WriteEventPostScreen = ({ navigation, route }) => {
   };
 
   useEffect(() => {
-    if (title && place && startDate && startTime && detailPlace) {
+    if (title && place && startDate && startTime && detailPlace && selectedImages.length > 0) {
       setIsButtonDisabled(false);
     } else {
       setIsButtonDisabled(true);
     }
-  }, [title, place, startDate, startTime, detailPlace]);
+  }, [title, place, startDate, startTime, detailPlace, selectedImages]);
 
   const handleSubmitEvent = async () => {
     const startDateTime = toISODateTimeString(startDate, startTime);

--- a/src/screens/Council/MyPage/CouncilCancelMembership.js
+++ b/src/screens/Council/MyPage/CouncilCancelMembership.js
@@ -84,16 +84,12 @@ const CouncilCancelMembershipScreen = ({ navigation }) => {
             <View style={styles.noticeItem}>
               <Text style={styles.noticeItemBullet}>•</Text>
               <Text style={styles.noticeItemText}>
-                탈퇴 즉시 00일 이내에는 동일 계정으로 다시 가입할 수 없습니다.
+                탈퇴 즉시 7일 이내에는 동일 계정으로 다시 가입할 수 없습니다.
               </Text>
             </View>
             <View style={styles.noticeItem}>
               <Text style={styles.noticeItemBullet}>•</Text>
               <Text style={styles.noticeItemText}>스탬프 소멸됩니다.</Text>
-            </View>
-            <View style={styles.noticeItem}>
-              <Text style={styles.noticeItemBullet}>•</Text>
-              <Text style={styles.noticeItemText}>등등</Text>
             </View>
           </View>
           <View style={styles.noticCheckWrapper}>

--- a/src/screens/Council/MyPage/CouncilEditProfileScreen.js
+++ b/src/screens/Council/MyPage/CouncilEditProfileScreen.js
@@ -17,6 +17,8 @@ import useAuthStore from '@store/authStore';
 import { changeCouncilNickname } from '@api/councilMyPage';
 import { getUserInfo } from '@api/user';
 
+const NICKNAME_REGEX = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$/;
+
 const CouncilEditProfileScreen = ({ navigation }) => {
   const { user } = useAuthStore();
   const [nickname, setNickname] = useState('');
@@ -61,10 +63,33 @@ const CouncilEditProfileScreen = ({ navigation }) => {
             value={nickname}
             onChangeText={(text) => {
               setNickname(text);
+              if (!NICKNAME_REGEX.test(text)) {
+                setNicknameError(true);
+                setErrorMessage('영문, 한글, 숫자만 사용 가능해요');
+              } else if (text.length > 0 && text.length < 2) {
+                setNicknameError(true);
+                setErrorMessage('2자 이상 입력해주세요');
+              } else {
+                setNicknameError(false);
+                setErrorMessage('');
+              }
             }}
             useTitle={true}
             title="학생회 이름"
+            hasError={nicknameError}
+            maxLength={15}
           />
+          {nicknameError && errorMessage && (
+            <View style={styles.errorMessageWrapper}>
+              <CheckIcon
+                width={11}
+                height={15}
+                style={{ marginRight: 8 }}
+                color={colors.common.error}
+              />
+              <Text style={styles.errorMessage}>{errorMessage}</Text>
+            </View>
+          )}
           {/* <Input
             disabled={true}
             isOrange={true}
@@ -79,7 +104,7 @@ const CouncilEditProfileScreen = ({ navigation }) => {
         <Button
           isOrange={true}
           title="다음"
-          disabled={!nickname}
+          disabled={!nickname || nickname.length < 2 || nicknameError}
           style={{
             width: '100%',
             height: 50,

--- a/src/screens/MyPage/CancelMembershipScreen.js
+++ b/src/screens/MyPage/CancelMembershipScreen.js
@@ -10,7 +10,6 @@ import colors from '../../style/colors';
 import typography from '../../style/typography';
 import LabelTitle from '../../components/LabelTitle';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { red } from 'react-native-reanimated/lib/typescript/Colors';
 import CheckIcon from '../../../assets/check.svg';
 import { useState } from 'react';
 import Button from '../../components/Button';
@@ -52,7 +51,6 @@ const CancelMembershipScreen = ({ navigation }) => {
         );
       }
     } catch (error) {
-      console.error(error);
       Alert.alert('오류', '알 수 없는 오류가 발생했습니다.');
     } finally {
       setIsLoading(false);
@@ -98,10 +96,6 @@ const CancelMembershipScreen = ({ navigation }) => {
             <View style={styles.noticeItem}>
               <Text style={styles.noticeItemBullet}>•</Text>
               <Text style={styles.noticeItemText}>스탬프 소멸됩니다.</Text>
-            </View>
-            <View style={styles.noticeItem}>
-              <Text style={styles.noticeItemBullet}>•</Text>
-              <Text style={styles.noticeItemText}>등등</Text>
             </View>
           </View>
           <View style={styles.noticCheckWrapper}>

--- a/src/screens/SignUp/StudentCouncil/FindRepresentativeId.js
+++ b/src/screens/SignUp/StudentCouncil/FindRepresentativeId.js
@@ -87,7 +87,7 @@ const FindRepresentativeId = ({ navigation }) => {
               학교 이메일(.ac.kr 또는 .edu)로 입력해주세요.
             </Text>
           )}
-          {/* {emailError && (
+          {emailError && (
             <Text
               style={{
                 ...typography.caption1Regular,
@@ -97,7 +97,7 @@ const FindRepresentativeId = ({ navigation }) => {
             >
               해당 이메일로 가입된 아이디가 없습니다.
             </Text>
-          )} */}
+          )}
         </ScrollView>
         <View style={styles.buttonContainer}>
           <Button

--- a/src/screens/SignUp/StudentCouncil/LoginRepresentative.js
+++ b/src/screens/SignUp/StudentCouncil/LoginRepresentative.js
@@ -76,11 +76,7 @@ const LoginRepresentative = ({ navigation }) => {
         errorMessage.includes('loginId')
       ) {
         setIdError(true);
-      } else if (
-        errorMessage.includes('비밀번호') ||
-        errorMessage.includes('일치') ||
-        errorMessage.includes('password')
-      ) {
+      } else {
         setPasswordError(true);
       }
       return;


### PR DESCRIPTION
## 📌 관련 이슈

close #152

<!--(이슈가 여러 개라면 콤마로 구분 ex. close #12, close #13)-->

## ✨ 변경 사항

학생회(Council) 2차 QA 항목 수정

## 🧩 세부 내용

- [x] 로그인: 틀린 비밀번호 입력 시 에러 문구 미표시 수정
- [x] 아이디 찾기: 미등록 이메일 에러 문구 표시 및 문구 수정 ("해당 이메일로 가입된 아이디가 없습니다.")
- [x] 게시글 삭제 팝업: 확인 버튼 색상 파란색 → 주황색 (`confirmButtonColor` prop 추가로 화면별 색상 분리)
- [x] 게시글 작성: 이미지 미선택 시 게시 버튼 비활성화 (이미지 필수값 처리)
- [x] 공지사항: 이벤트 안내 탭 중복 표시 수정 (3개 → 2개)
- [x] 닉네임 변경: 닉네임 정책 검증 추가 (영문·한글·숫자, 2자 이상, 15자 이하)
- [x] 회원 탈퇴(학생회/학생 공통): 유의사항 문구 수정 ("00일" → "7일") 및 미완성 항목 제거


## 📸 스크린샷 (선택)

## 💬 기타 참고사항

> 리뷰어가 알아야 할 추가 내용

<!-- ex) API 미완성, 임시 데이터 사용 중 등-->
